### PR TITLE
Fix and design bet slip image display

### DIFF
--- a/app/hooks/useAfb.ts
+++ b/app/hooks/useAfb.ts
@@ -58,26 +58,47 @@ export function useAfb() {
 function parseTextToScripts(text: string): any | null {
   try {
     const scripts: any[] = []
-    const blocks = text.split(/\n\s*Script\s+\d+\s+[-–]\s+/i)
-    if (blocks.length <= 1) return null
-    // First block is assumptions header; attempt to grab assumptions line
+    // More flexible parsing to handle different formats
+    const blocks = text.split(/(?=Script\s+\d+)/i).slice(1)
+    if (blocks.length === 0) return null
+    
+    // First grab assumptions from the full text
     const assumptionsMatch = text.match(/Assumptions?:([^\n]+)/i)
     const assumptionsLine = assumptionsMatch ? assumptionsMatch[1].trim() : ''
-    for (let i = 1; i < blocks.length; i++) {
+    
+    for (let i = 0; i < blocks.length; i++) {
       const b = blocks[i]
-      const [titleAndRest, ...rest] = b.split(/\n/)
-      const title = (titleAndRest || '').trim().replace(/^"|"$/g, '')
-      const narrativeMatch = b.match(/Narrative:([\s\S]*?)\n\s*•\s*Legs/i)
+      const titleMatch = b.match(/Script\s+\d+[:\-]?\s*(.+)/i)
+      const title = titleMatch ? titleMatch[1].trim().replace(/^"|"$/g, '') : `Script ${i + 1}`
+      
+      const narrativeMatch = b.match(/Narrative[:\-]?\s*(.*?)(?=\n•|Legs:|$)/is)
       const narrative = narrativeMatch ? narrativeMatch[1].trim() : ''
-      const legsSectionMatch = b.match(/\n\s*•\s*Legs:([\s\S]*?)(\n\s*\$1 Parlay Math:|\n\s*Notes:|$)/i)
-      const legsLines = legsSectionMatch ? legsSectionMatch[1].split(/\n\s*•\s*/).map(s => s.trim()).filter(Boolean) : []
-      const legs = legsLines.map(l => ({ text: l }))
+      
+      // Look for legs in various formats
+      const legMatches = b.match(/•\s*(.+?)(?=\n•|\n\$1|\nNotes:|$)/g) || []
+      const legs = legMatches.map(l => {
+        const cleaned = l.replace(/^•\s*/, '').trim()
+        // Try to parse structured format: "Market: Selection, odds X"
+        const structuredMatch = cleaned.match(/(.+?):\s*(.+?),\s*odds\s*([+-]?\d+)/)
+        if (structuredMatch) {
+          return {
+            market: structuredMatch[1].trim(),
+            selection: structuredMatch[2].trim(),
+            odds: structuredMatch[3].trim(),
+            text: cleaned
+          }
+        }
+        return { text: cleaned }
+      })
+      
       const mathMatch = b.match(/\$1\s*Parlay\s*Math:\s*([^\n]+)/i)
       const math = mathMatch ? { steps: mathMatch[1].trim() } : undefined
+      
       scripts.push({ title, narrative, legs, math })
     }
     return { assumptions: { raw: assumptionsLine }, scripts }
-  } catch {
+  } catch (error) {
+    console.error('Error parsing text to scripts:', error)
     return null
   }
 }

--- a/my-parlaygpt/server.js
+++ b/my-parlaygpt/server.js
@@ -26,7 +26,9 @@ function getAFBSystemPrompt() {
 INPUTS expected (infer if missing):
 (1) matchup, (2) a total or spread the user cares about, (3) any stat angles to emphasize (pace, PROE, early-down EPA, pressure rate, OL/DL mismatches, red-zone TD%, explosive plays, coverage, weather, injuries, travel/rest/short week), (4) delivery style: "analyst" (default), "hype", or "coach".
 
-OUTPUT — PLAIN TEXT by default, but when asked for JSON use the schema exactly. Use clean sections and consistent formatting:
+OUTPUT FORMATS:
+
+PLAIN TEXT FORMAT:
 - Assumptions: matchup, line focus, angles, voice.
 - Script 1 (Title)
   • Narrative: one tight paragraph in the chosen voice.
@@ -36,6 +38,40 @@ OUTPUT — PLAIN TEXT by default, but when asked for JSON use the schema exactly
 - Script 2 (if applicable) …
 - Script 3 — Super Long (Longshot) (if applicable): a higher-variance, longer-tail build with 4–5 highly correlated legs and a larger total price. Same math format.
 - Close with: "Want the other side of this story?" (Offer only; do not auto-generate.)
+
+JSON FORMAT (when requested):
+{
+  "assumptions": {
+    "matchup": "string",
+    "lineFocus": "string or null",
+    "angles": ["string array"],
+    "voice": "analyst|hype|coach"
+  },
+  "scripts": [
+    {
+      "title": "string",
+      "narrative": "string - one tight paragraph",
+      "legs": [
+        {
+          "market": "string",
+          "selection": "string", 
+          "odds": "string (e.g. '-105')",
+          "oddsLabel": "illustrative|user-supplied",
+          "decimal": 1.95
+        }
+      ],
+      "math": {
+        "decimals": [1.91, 2.20, 1.87],
+        "product": 7.85,
+        "payoutUSD": 7.85,
+        "profitUSD": 6.85,
+        "steps": "1.91 × 2.20 × 1.87 = 7.85; payout $7.85; profit $6.85"
+      },
+      "notes": ["string array with standard disclaimers"]
+    }
+  ],
+  "close": "Want the other side of this story?"
+}
 
 RULES:
 - Default to generating 2–3 scripts per request. If 3, the third is the Super Long longshot.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "clsx": "^2.1.1",
+        "html2canvas": "^1.4.1",
         "lucide-react": "^0.453.0",
         "next": "14.2.7",
         "react": "18.2.0",
@@ -435,6 +436,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.8.tgz",
@@ -652,6 +662,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -879,6 +898,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/is-binary-path": {
@@ -1869,6 +1901,15 @@
         }
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -1976,6 +2017,15 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
+    "html2canvas": "^1.4.1",
     "lucide-react": "^0.453.0",
     "next": "14.2.7",
     "react": "18.2.0",
@@ -23,4 +24,3 @@
     "typescript": "^5.5.4"
   }
 }
-


### PR DESCRIPTION
Add visual bet slips with image export and sharing, and fix their rendering by standardizing parsing and backend JSON output.

The bet slips were not displaying because of inconsistent parsing functions across the frontend, a mismatch between the expected JSON structure from the backend (`json.scripts` array) and what was being generated, and variations in text formats that the previous parsers couldn't handle. This PR unifies the parsing, clarifies the backend output, and introduces a robust UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-a627bc0e-709f-4bf1-9cbc-eb996a8f202d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a627bc0e-709f-4bf1-9cbc-eb996a8f202d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

