### PR TITLE
feat: wrapper auth + context trace + Playwright smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,5 +52,13 @@ npm start        # Next start (prod)
 ```
 (Backend runs separately: `cd my-parlaygpt && npm start`)
 
+## Smoke Tests (Local)
+```bash
+npx playwright install
+npx playwright test
+```
+Notes:
+- Tests mock `/api/afb`, so no external services are called.
+
 ## License
 MIT

--- a/docs/plans/2026-01-15-playwright-smoke-design.md
+++ b/docs/plans/2026-01-15-playwright-smoke-design.md
@@ -1,0 +1,24 @@
+# Playwright Smoke Tests Design
+
+Goal
+- Add local-only Playwright flow tests that validate the UI wiring to /api/afb and error handling without hitting external services.
+
+Architecture
+- Use Playwright with a local dev server (npm run dev) launched by Playwright config.
+- Intercept /api/afb in tests and return a deterministic Swantail JSON payload to keep tests stable and fast.
+- Include a negative-flow test that returns a 500 and asserts the UI error banner appears.
+
+Scope
+- Page load smoke: app renders and primary CTA is visible.
+- Happy path: submit a matchup + line focus + angle and verify scripts render.
+- Error path: simulate /api/afb failure and confirm error message displays.
+
+Stability
+- No network calls to wrapper/OpenAI; all /api/afb calls are mocked in tests.
+- Tests run locally only (no CI/cron), using `npx playwright test`.
+
+Dependencies
+- Playwright test runner as dev dependency and basic config in repository root.
+
+Developer Docs
+- Add a short README section on how to run smoke tests and expected local prerequisites.

--- a/docs/plans/2026-01-15-playwright-smoke.md
+++ b/docs/plans/2026-01-15-playwright-smoke.md
@@ -1,0 +1,177 @@
+# Playwright Smoke Tests Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add local-only Playwright flow tests that validate the UI wiring to /api/afb with deterministic mocks and an error path.
+
+**Architecture:** Playwright launches the Next dev server, intercepts /api/afb calls to return fixed JSON, and asserts UI outputs. No external network calls during tests.
+
+**Tech Stack:** Next.js, Playwright.
+
+### Task 1: Add Playwright config and dependencies
+
+**Files:**
+- Modify: `package.json`
+- Create: `playwright.config.ts`
+
+**Step 1: Write a failing smoke test placeholder**
+
+```ts
+import { test, expect } from '@playwright/test'
+
+test('smoke placeholder', async ({ page }) => {
+  await page.goto('http://localhost:3000')
+  await expect(page.getByRole('button', { name: /reveal scripts/i })).toBeVisible()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx playwright test`
+Expected: FAIL (playwright not installed / config missing)
+
+**Step 3: Add Playwright dev dependency and config**
+
+- Add `@playwright/test` to devDependencies.
+- Add `playwright.config.ts` with:
+  - `webServer.command = "npm run dev"`
+  - `webServer.port = 3000`
+  - `use.baseURL = "http://localhost:3000"`
+  - headless true by default
+
+**Step 4: Run test to verify it passes**
+
+Run: `npx playwright test`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add package.json playwright.config.ts
+git commit -m "test: add Playwright config"
+```
+
+### Task 2: Implement happy-path flow test with /api/afb mock
+
+**Files:**
+- Create: `tests/e2e/afb-happy.spec.ts`
+
+**Step 1: Write failing test**
+
+```ts
+import { test, expect } from '@playwright/test'
+
+const mockResponse = {
+  assumptions: { matchup: 'A @ B', line_focus: 'Over 41.5', angles: ['Pace skew'], voice: 'analyst' },
+  scripts: [
+    {
+      title: 'Fast Start',
+      narrative: 'Test narrative',
+      legs: [
+        { market: 'Total', selection: 'Over 41.5', american_odds: -110, odds_source: 'illustrative' },
+        { market: 'Spread', selection: 'B -3.5', american_odds: -105, odds_source: 'illustrative' },
+        { market: 'TD', selection: 'RB Anytime', american_odds: +120, odds_source: 'illustrative' }
+      ],
+      parlay_math: { stake: 1, leg_decimals: [1.91, 1.95, 2.2], product_decimal: 8.2, payout: 8.2, profit: 7.2, steps: '1.91 × 1.95 × 2.20 = 8.20; payout $8.20; profit $7.20.' },
+      notes: ['No guarantees; high variance by design; bet what you can afford.', 'If odds not supplied, american odds are illustrative — paste your book\'s prices to re-price.'],
+      offer_opposite: 'Want the other side of this story?'
+    }
+  ]
+}
+
+test('builds scripts from mocked /api/afb', async ({ page }) => {
+  await page.route('**/api/afb', route => route.fulfill({ json: mockResponse }))
+  await page.goto('/')
+  await page.getByLabel(/matchup/i).fill('A @ B')
+  await page.getByRole('button', { name: /reveal scripts/i }).click()
+  await expect(page.getByText('Fast Start')).toBeVisible()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx playwright test tests/e2e/afb-happy.spec.ts`
+Expected: FAIL (selectors may need adjustment)
+
+**Step 3: Adjust selectors to real UI**
+
+- Use matchup field from `SwantailBuilderForm` (label or placeholder).
+- Ensure button text matches "Reveal scripts".
+
+**Step 4: Run test to verify it passes**
+
+Run: `npx playwright test tests/e2e/afb-happy.spec.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tests/e2e/afb-happy.spec.ts
+git commit -m "test: add AFB happy-path flow"
+```
+
+### Task 3: Add error-path flow test
+
+**Files:**
+- Create: `tests/e2e/afb-error.spec.ts`
+
+**Step 1: Write failing test**
+
+```ts
+import { test, expect } from '@playwright/test'
+
+test('shows error when /api/afb fails', async ({ page }) => {
+  await page.route('**/api/afb', route => route.fulfill({ status: 500, json: { message: 'boom' } }))
+  await page.goto('/')
+  await page.getByLabel(/matchup/i).fill('A @ B')
+  await page.getByRole('button', { name: /reveal scripts/i }).click()
+  await expect(page.getByText('boom')).toBeVisible()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx playwright test tests/e2e/afb-error.spec.ts`
+Expected: FAIL (selectors may need adjustment)
+
+**Step 3: Adjust selectors to real UI**
+
+- Align error text selector with error rendering in `components/AssistedBuilder.tsx`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `npx playwright test tests/e2e/afb-error.spec.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add tests/e2e/afb-error.spec.ts
+git commit -m "test: add AFB error flow"
+```
+
+### Task 4: Document local run steps
+
+**Files:**
+- Modify: `README.md`
+
+**Step 1: Add Playwright run instructions**
+
+```md
+## Smoke Tests (Local)
+
+```bash
+npx playwright install
+npx playwright test
+```
+
+Notes:
+- Tests mock `/api/afb`, so no external services are called.
+```
+
+**Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: add Playwright smoke test instructions"
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@playwright/test": "^1.57.0",
         "@types/node": "^20.14.9",
         "@types/react": "^18.2.79",
         "autoprefixer": "^10.4.19",
@@ -294,6 +295,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@swc/counter": {
@@ -1776,6 +1793,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start -p 3000"
+    "start": "next start -p 3000",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@vercel/analytics": "^1.5.0",
@@ -22,6 +23,7 @@
     "@types/node": "^20.14.9",
     "@types/react": "^18.2.79",
     "autoprefixer": "^10.4.19",
+    "@playwright/test": "^1.57.0",
     "postcss": "^8.4.39",
     "tailwindcss": "^3.4.10",
     "typescript": "^5.5.4"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 60_000,
+  retries: 0,
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'npm run dev',
+    port: 3000,
+    reuseExistingServer: true,
+  },
+})

--- a/tests/e2e/afb-error.spec.ts
+++ b/tests/e2e/afb-error.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test'
+
+test('shows error when /api/afb fails', async ({ page }) => {
+  await page.route('**/api/afb', route => route.fulfill({ status: 500, json: { message: 'boom' } }))
+  await page.goto('/')
+
+  const matchupInput = page.getByLabel(/matchup/i)
+  if (await matchupInput.count()) {
+    await matchupInput.fill('A @ B')
+  } else {
+    await page.getByPlaceholder('Lions @ Eagles').fill('A @ B')
+  }
+
+  await page.getByRole('button', { name: /reveal scripts/i }).click()
+  await expect(page.getByText('boom')).toBeVisible()
+})

--- a/tests/e2e/afb-happy.spec.ts
+++ b/tests/e2e/afb-happy.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test'
+
+const mockResponse = {
+  assumptions: { matchup: 'A @ B', line_focus: 'Over 41.5', angles: ['Pace skew'], voice: 'analyst' },
+  scripts: [
+    {
+      title: 'Fast Start',
+      narrative: 'Test narrative',
+      legs: [
+        { market: 'Total', selection: 'Over 41.5', american_odds: -110, odds_source: 'illustrative' },
+        { market: 'Spread', selection: 'B -3.5', american_odds: -105, odds_source: 'illustrative' },
+        { market: 'TD', selection: 'RB Anytime', american_odds: 120, odds_source: 'illustrative' }
+      ],
+      parlay_math: {
+        stake: 1,
+        leg_decimals: [1.91, 1.95, 2.2],
+        product_decimal: 8.2,
+        payout: 8.2,
+        profit: 7.2,
+        steps: '1.91 × 1.95 × 2.20 = 8.20; payout $8.20; profit $7.20.'
+      },
+      notes: [
+        'No guarantees; high variance by design; bet what you can afford.',
+        "If odds not supplied, american odds are illustrative — paste your book's prices to re-price."
+      ],
+      offer_opposite: 'Want the other side of this story?'
+    }
+  ]
+}
+
+test('builds scripts from mocked /api/afb', async ({ page }) => {
+  await page.route('**/api/afb', route => route.fulfill({ json: mockResponse }))
+  await page.goto('/')
+
+  const matchupInput = page.getByLabel(/matchup/i)
+  if (await matchupInput.count()) {
+    await matchupInput.fill('A @ B')
+  } else {
+    await page.getByPlaceholder('Lions @ Eagles').fill('A @ B')
+  }
+
+  await page.getByRole('button', { name: /reveal scripts/i }).click()
+  await expect(page.getByText('Fast Start')).toBeVisible()
+})


### PR DESCRIPTION
## What
- Enforce optional auth and request deadline in wrapper, allow unauthenticated /api/health
- Add context hashing utilities and propagate request_id/context metadata in Next API responses
- Add Playwright smoke tests (happy path + error path) with mocked /api/afb
- Add local smoke test instructions to README

## Why
- Secure wrapper without breaking local dev
- Traceability for context/provenance and request correlation
- Fast, deterministic end-to-end smoke coverage for UI/API wiring

## Testing
- npm test -- --runTestsByPath __tests__/wrapperAuth.test.js (my-parlaygpt)
- npm test -- --runTestsByPath __tests__/contextHash.test.js (my-parlaygpt)
- node --test __tests__/context-hash.test.js
- npx playwright install
- npx playwright test

## Notes
- /api/health bypasses auth to simplify Render monitoring
- /api/afb still requires Authorization header

## Deployment Notes (Render/Vercel)

**Render (wrapper) env vars**
- NODE_ENV=production
- GPT_API_KEY=<key> (or OPENAI_API_KEY)
- WRAPPER_AUTH_TOKEN=<shared secret>
- WRAPPER_AUTH_HEADER=Authorization
- WRAPPER_ALLOWED_ORIGINS=https://afb-parley.vercel.app,http://localhost:3000
- WRAPPER_TIMEOUT_MS=25000 (optional)

**Vercel (frontend) env vars**
- WRAPPER_BASE_URL=https://afbparley.onrender.com
- WRAPPER_ENDPOINT_PATH=/api/afb
- WRAPPER_AUTH_HEADER=Authorization
- WRAPPER_AUTH_TOKEN=<shared secret>
- WRAPPER_TIMEOUT_MS=20000 (optional)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces local Playwright smoke testing to validate UI→`/api/afb` wiring without external calls.
> 
> - Add `playwright.config.ts` to launch the Next dev server and set `baseURL`/headless defaults
> - New E2E tests: `tests/e2e/afb-happy.spec.ts` (mocked success) and `tests/e2e/afb-error.spec.ts` (mocked 500) via request interception
> - Update `package.json`: add `@playwright/test` dev dependency and `test:e2e` script; lockfile updated
> - README: add “Smoke Tests (Local)” run instructions
> - Add design/implementation docs under `docs/plans/`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7254e63a39f8311b39081ccd1da3de2cb2ad6e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->