### PR TITLE
feat: Swantail Terminal - Agent-based betting analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ out/
 
 # TypeScript
 *.tsbuildinfo
+
+# Worktrees
+.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ yarn-error.log*
 # Production builds
 dist/
 build/
+!app/api/terminal/build/
 
 # Environment variables
 .env

--- a/__tests__/api/terminal/bet.test.ts
+++ b/__tests__/api/terminal/bet.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi } from 'vitest'
+import { POST, GET } from '@/app/api/terminal/bet/route'
+import { NextRequest } from 'next/server'
+
+// Mock crypto for provenance hashing
+vi.mock('crypto', () => ({
+  createHash: () => ({
+    update: () => ({
+      digest: () => 'mocked-hash-123',
+    }),
+  }),
+}))
+
+function createRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/terminal/bet', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('/api/terminal/bet POST', () => {
+  it('returns 400 for invalid request body', async () => {
+    const req = createRequest({ invalid: true })
+    const response = await POST(req)
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('Invalid request')
+  })
+
+  it('returns 400 when alert_ids is empty', async () => {
+    const req = createRequest({
+      alert_ids: [],
+      alert_metadata: [],
+    })
+    const response = await POST(req)
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('Invalid request')
+  })
+
+  it('creates safe tier ladder for high confidence alerts', async () => {
+    const req = createRequest({
+      alert_ids: ['epa-1', 'pressure-1'],
+      alert_metadata: [
+        {
+          id: 'epa-1',
+          agent: 'epa',
+          market: 'Chase Over 85.5 Yards',
+          line: 85.5,
+          confidence: 0.8,
+          severity: 'high',
+          claim: 'Elite efficiency vs weak coverage',
+        },
+        {
+          id: 'pressure-1',
+          agent: 'pressure',
+          market: 'Bosa 1+ Sacks',
+          confidence: 0.75,
+          severity: 'high',
+        },
+      ],
+    })
+    const response = await POST(req)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.ladders.some((l: { tier: string }) => l.tier === 'safe')).toBe(true)
+  })
+
+  it('creates moderate tier ladder for medium confidence alerts', async () => {
+    const req = createRequest({
+      alert_ids: ['qb-1'],
+      alert_metadata: [
+        {
+          id: 'qb-1',
+          agent: 'qb',
+          market: 'Burrow Over 275.5 Pass Yards',
+          confidence: 0.6,
+          severity: 'medium',
+        },
+      ],
+    })
+    const response = await POST(req)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.ladders.some((l: { tier: string }) => l.tier === 'moderate')).toBe(true)
+  })
+
+  it('creates aggressive tier ladder for lower confidence alerts', async () => {
+    const req = createRequest({
+      alert_ids: ['hb-1', 'wr-1'],
+      alert_metadata: [
+        {
+          id: 'hb-1',
+          agent: 'hb',
+          market: 'RB Over 75.5 Rush Yards',
+          confidence: 0.4,
+          severity: 'medium',
+        },
+        {
+          id: 'wr-1',
+          agent: 'wr',
+          market: 'WR Over 100.5 Yards',
+          confidence: 0.35,
+          severity: 'medium',
+        },
+      ],
+    })
+    const response = await POST(req)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.ladders.some((l: { tier: string }) => l.tier === 'aggressive')).toBe(true)
+  })
+
+  it('excludes aggressive tier when include_aggressive is false', async () => {
+    const req = createRequest({
+      alert_ids: ['hb-1'],
+      alert_metadata: [
+        {
+          id: 'hb-1',
+          agent: 'hb',
+          market: 'RB Over 75.5 Rush Yards',
+          confidence: 0.4,
+          severity: 'medium',
+        },
+      ],
+      options: { include_aggressive: false },
+    })
+    const response = await POST(req)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.ladders.some((l: { tier: string }) => l.tier === 'aggressive')).toBe(false)
+  })
+
+  it('respects max_rungs_per_ladder option', async () => {
+    const req = createRequest({
+      alert_ids: ['epa-1', 'epa-2', 'epa-3', 'epa-4'],
+      alert_metadata: [
+        { id: 'epa-1', agent: 'epa', market: 'M1', confidence: 0.8, severity: 'high' },
+        { id: 'epa-2', agent: 'epa', market: 'M2', confidence: 0.75, severity: 'high' },
+        { id: 'epa-3', agent: 'epa', market: 'M3', confidence: 0.72, severity: 'high' },
+        { id: 'epa-4', agent: 'epa', market: 'M4', confidence: 0.7, severity: 'high' },
+      ],
+      options: { max_rungs_per_ladder: 2 },
+    })
+    const response = await POST(req)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    for (const ladder of data.ladders) {
+      expect(ladder.rungs.length).toBeLessThanOrEqual(2)
+    }
+  })
+
+  it('returns empty ladders when no alerts qualify', async () => {
+    const req = createRequest({
+      alert_ids: ['low-conf-1'],
+      alert_metadata: [
+        {
+          id: 'low-conf-1',
+          agent: 'te',
+          market: 'TE Over 30.5 Yards',
+          confidence: 0.2, // Too low for any tier
+          severity: 'high',
+        },
+      ],
+    })
+    const response = await POST(req)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.ladders).toHaveLength(0)
+    expect(data.alerts_excluded).toContain('low-conf-1')
+  })
+
+  it('includes stake recommendations', async () => {
+    const req = createRequest({
+      alert_ids: ['epa-1'],
+      alert_metadata: [
+        {
+          id: 'epa-1',
+          agent: 'epa',
+          market: 'Chase Over 85.5 Yards',
+          confidence: 0.8,
+          severity: 'high',
+        },
+      ],
+    })
+    const response = await POST(req)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    if (data.ladders.length > 0) {
+      expect(data.ladders[0].recommended_stake_pct).toBeDefined()
+      expect(data.ladders[0].recommended_stake_pct).toBeGreaterThan(0)
+      expect(data.ladders[0].recommended_stake_pct).toBeLessThanOrEqual(10)
+    }
+  })
+
+  it('includes provenance hash and timing', async () => {
+    const req = createRequest({
+      alert_ids: ['epa-1'],
+      alert_metadata: [
+        {
+          id: 'epa-1',
+          agent: 'epa',
+          market: 'Test Market',
+          confidence: 0.7,
+          severity: 'high',
+        },
+      ],
+    })
+    const response = await POST(req)
+    const data = await response.json()
+
+    expect(data.provenance_hash).toBeDefined()
+    expect(data.bet_timestamp).toBeDefined()
+    expect(data.timing_ms).toBeDefined()
+    expect(data.request_id).toBeDefined()
+  })
+
+  it('builds rungs with rationale from claim or default', async () => {
+    const req = createRequest({
+      alert_ids: ['epa-1', 'pressure-1'],
+      alert_metadata: [
+        {
+          id: 'epa-1',
+          agent: 'epa',
+          market: 'Chase Over 85.5',
+          confidence: 0.8,
+          severity: 'high',
+          claim: 'Custom claim text here',
+        },
+        {
+          id: 'pressure-1',
+          agent: 'pressure',
+          market: 'Bosa 1+ Sacks',
+          confidence: 0.75,
+          severity: 'high',
+          // No claim - should use default
+        },
+      ],
+    })
+    const response = await POST(req)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+
+    const safeLadder = data.ladders.find((l: { tier: string }) => l.tier === 'safe')
+    if (safeLadder) {
+      const epaRung = safeLadder.rungs.find((r: { alert_id: string }) => r.alert_id === 'epa-1')
+      const pressureRung = safeLadder.rungs.find((r: { alert_id: string }) => r.alert_id === 'pressure-1')
+
+      if (epaRung) {
+        expect(epaRung.rationale).toBe('Custom claim text here')
+      }
+      if (pressureRung) {
+        expect(pressureRung.rationale).toContain('PRESSURE agent signal')
+      }
+    }
+  })
+})
+
+describe('/api/terminal/bet GET', () => {
+  it('returns endpoint documentation', async () => {
+    const response = await GET()
+    const data = await response.json()
+
+    expect(data.endpoint).toBe('/api/terminal/bet')
+    expect(data.method).toBe('POST')
+    expect(data.schema).toBeDefined()
+    expect(data.risk_tiers).toBeDefined()
+    expect(data.stake_recommendations).toBeDefined()
+    expect(data.example).toBeDefined()
+  })
+})

--- a/__tests__/api/terminal/build.test.ts
+++ b/__tests__/api/terminal/build.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { POST, GET } from '@/app/api/terminal/build/route'
+import { NextRequest } from 'next/server'
+
+// Mock crypto for provenance hashing
+vi.mock('crypto', () => ({
+  createHash: () => ({
+    update: () => ({
+      digest: () => 'mocked-hash-123',
+    }),
+  }),
+}))
+
+function createRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/terminal/build', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('/api/terminal/build POST', () => {
+  it('returns 400 for invalid request body', async () => {
+    const req = createRequest({ invalid: true })
+    const response = await POST(req)
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('Invalid request')
+  })
+
+  it('returns 400 when alert_ids has less than 2 items', async () => {
+    const req = createRequest({
+      alert_ids: ['single-alert'],
+      alert_metadata: [{ id: 'single-alert', agent: 'epa', market: 'Test', confidence: 0.5 }],
+    })
+    const response = await POST(req)
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe('Invalid request')
+  })
+
+  it('builds scripts from weather cascade correlation', async () => {
+    const req = createRequest({
+      alert_ids: ['weather-1', 'qb-1', 'wr-1'],
+      alert_metadata: [
+        { id: 'weather-1', agent: 'weather', market: 'Game Total Under 42.5', confidence: 0.65 },
+        { id: 'qb-1', agent: 'qb', market: 'Burrow Under 275.5 Pass', confidence: 0.6 },
+        { id: 'wr-1', agent: 'wr', market: 'Chase Under 100.5 Yards', confidence: 0.55 },
+      ],
+    })
+    const response = await POST(req)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.scripts.length).toBeGreaterThan(0)
+    expect(data.scripts[0].correlation_type).toBe('weather_cascade')
+    expect(data.alerts_used).toContain('weather-1')
+  })
+
+  it('builds scripts from defensive funnel correlation', async () => {
+    const req = createRequest({
+      alert_ids: ['pressure-1', 'qb-1'],
+      alert_metadata: [
+        { id: 'pressure-1', agent: 'pressure', market: 'Defense 3+ Sacks', confidence: 0.7 },
+        { id: 'qb-1', agent: 'qb', market: 'QB Under 250.5 Pass Yards', confidence: 0.65 },
+      ],
+    })
+    const response = await POST(req)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.scripts.some((s: { correlation_type: string }) => s.correlation_type === 'defensive_funnel')).toBe(true)
+  })
+
+  it('returns empty scripts when no correlations found', async () => {
+    const req = createRequest({
+      alert_ids: ['te-1', 'te-2'],
+      alert_metadata: [
+        { id: 'te-1', agent: 'te', market: 'TE 1 Over 45.5 Yards', confidence: 0.5 },
+        { id: 'te-2', agent: 'te', market: 'TE 2 Over 40.5 Yards', confidence: 0.5 },
+      ],
+    })
+    const response = await POST(req)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.scripts).toHaveLength(0)
+    expect(data.alerts_excluded).toContain('te-1')
+    expect(data.alerts_excluded).toContain('te-2')
+  })
+
+  it('includes provenance hash and timing', async () => {
+    const req = createRequest({
+      alert_ids: ['weather-1', 'qb-1'],
+      alert_metadata: [
+        { id: 'weather-1', agent: 'weather', market: 'Under 42.5', confidence: 0.6 },
+        { id: 'qb-1', agent: 'qb', market: 'Under 250.5', confidence: 0.55 },
+      ],
+    })
+    const response = await POST(req)
+    const data = await response.json()
+
+    expect(data.provenance_hash).toBeDefined()
+    expect(data.build_timestamp).toBeDefined()
+    expect(data.timing_ms).toBeDefined()
+    expect(data.request_id).toBeDefined()
+  })
+
+  it('respects max_legs option', async () => {
+    const req = createRequest({
+      alert_ids: ['weather-1', 'qb-1', 'wr-1', 'te-1'],
+      alert_metadata: [
+        { id: 'weather-1', agent: 'weather', market: 'Under 42.5', confidence: 0.6 },
+        { id: 'qb-1', agent: 'qb', market: 'Under 250.5', confidence: 0.55 },
+        { id: 'wr-1', agent: 'wr', market: 'Over 75.5', confidence: 0.5 },
+        { id: 'te-1', agent: 'te', market: 'Over 40.5', confidence: 0.5 },
+      ],
+      options: { max_legs: 2 },
+    })
+    const response = await POST(req)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    // Each script should have at most 2 legs
+    for (const script of data.scripts) {
+      expect(script.legs.length).toBeLessThanOrEqual(2)
+    }
+  })
+
+  it('assigns appropriate risk levels', async () => {
+    const req = createRequest({
+      alert_ids: ['weather-1', 'qb-1'],
+      alert_metadata: [
+        { id: 'weather-1', agent: 'weather', market: 'Under 42.5', confidence: 0.8 },
+        { id: 'qb-1', agent: 'qb', market: 'Under 250.5', confidence: 0.75 },
+      ],
+    })
+    const response = await POST(req)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    if (data.scripts.length > 0) {
+      // High confidence 2-leg should be conservative
+      expect(['conservative', 'moderate']).toContain(data.scripts[0].risk_level)
+    }
+  })
+})
+
+describe('/api/terminal/build GET', () => {
+  it('returns endpoint documentation', async () => {
+    const response = await GET()
+    const data = await response.json()
+
+    expect(data.endpoint).toBe('/api/terminal/build')
+    expect(data.method).toBe('POST')
+    expect(data.schema).toBeDefined()
+    expect(data.correlation_types).toBeDefined()
+    expect(data.example).toBeDefined()
+  })
+})

--- a/__tests__/terminal/agents/epa.test.ts
+++ b/__tests__/terminal/agents/epa.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest'
+import { EPA_THRESHOLDS, checkEpaThresholds } from '@/lib/terminal/agents/epa/thresholds'
+
+describe('EPA_THRESHOLDS', () => {
+  it('has defined threshold values', () => {
+    expect(EPA_THRESHOLDS.receivingEpaRank).toBe(10)
+    expect(EPA_THRESHOLDS.epaAllowedRank).toBe(10)
+    expect(EPA_THRESHOLDS.rushingEpaDiff).toBe(0.15)
+  })
+})
+
+describe('checkEpaThresholds', () => {
+  const NOW = Date.now()
+
+  it('returns finding when receiving EPA rank meets threshold', () => {
+    const playerData = {
+      name: 'Jaxon Smith-Njigba',
+      team: 'SEA',
+      receiving_epa_rank: 3,
+      targets: 120,
+    }
+    const opponentData = {
+      team: 'SF',
+      epa_allowed_to_wr_rank: 8,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkEpaThresholds(playerData, opponentData, context)
+
+    expect(findings.length).toBeGreaterThan(0)
+    expect(findings[0].agent).toBe('epa')
+    expect(findings[0].type).toBe('receiving_epa_mismatch')
+    expect(findings[0].stat).toBe('receiving_epa_rank')
+    expect(findings[0].value_num).toBe(3)
+  })
+
+  it('returns empty when player rank not in top 10', () => {
+    const playerData = {
+      name: 'Random Player',
+      team: 'NYG',
+      receiving_epa_rank: 45,
+      targets: 80,
+    }
+    const opponentData = {
+      team: 'DAL',
+      epa_allowed_to_wr_rank: 5,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkEpaThresholds(playerData, opponentData, context)
+
+    expect(findings.length).toBe(0)
+  })
+
+  it('returns empty when opponent defense not vulnerable', () => {
+    const playerData = {
+      name: 'Good Player',
+      team: 'KC',
+      receiving_epa_rank: 5,
+      targets: 100,
+    }
+    const opponentData = {
+      team: 'NE',
+      epa_allowed_to_wr_rank: 25, // Good defense
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkEpaThresholds(playerData, opponentData, context)
+
+    expect(findings.length).toBe(0)
+  })
+
+  it('returns empty when sample size too small', () => {
+    const playerData = {
+      name: 'New Player',
+      team: 'CHI',
+      receiving_epa_rank: 2,
+      targets: 30, // Below threshold
+    }
+    const opponentData = {
+      team: 'DET',
+      epa_allowed_to_wr_rank: 5,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkEpaThresholds(playerData, opponentData, context)
+
+    expect(findings.length).toBe(0)
+  })
+
+  it('returns finding for rushing EPA mismatch', () => {
+    const playerData = {
+      name: 'Christian McCaffrey',
+      team: 'SF',
+      rushing_epa_rank: 2,
+      rushes: 200,
+    }
+    const opponentData = {
+      team: 'SEA',
+      epa_allowed_to_rb_rank: 6,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkEpaThresholds(playerData, opponentData, context)
+
+    expect(findings.length).toBeGreaterThan(0)
+    expect(findings[0].agent).toBe('epa')
+    expect(findings[0].type).toBe('rushing_epa_mismatch')
+    expect(findings[0].stat).toBe('rushing_epa_rank')
+  })
+
+  it('returns multiple findings for dual-threat player', () => {
+    const playerData = {
+      name: 'Josh Allen',
+      team: 'BUF',
+      receiving_epa_rank: 8, // Hypothetical
+      rushing_epa_rank: 5,
+      targets: 60,
+      rushes: 100,
+    }
+    const opponentData = {
+      team: 'MIA',
+      epa_allowed_to_wr_rank: 3,
+      epa_allowed_to_rb_rank: 4,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkEpaThresholds(playerData, opponentData, context)
+
+    expect(findings.length).toBe(2)
+    expect(findings.map(f => f.type)).toContain('receiving_epa_mismatch')
+    expect(findings.map(f => f.type)).toContain('rushing_epa_mismatch')
+  })
+
+  it('generates deterministic IDs', () => {
+    const playerData = {
+      name: 'Test Player',
+      team: 'TEST',
+      receiving_epa_rank: 5,
+      targets: 100,
+    }
+    const opponentData = {
+      team: 'OPP',
+      epa_allowed_to_wr_rank: 5,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkEpaThresholds(playerData, opponentData, context)
+
+    expect(findings[0].id).toMatch(/^epa-test-player-recv-\d+$/)
+  })
+})

--- a/__tests__/terminal/agents/hb.test.ts
+++ b/__tests__/terminal/agents/hb.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest'
+import { HB_THRESHOLDS, checkHbThresholds } from '@/lib/terminal/agents/hb/thresholds'
+
+describe('HB_THRESHOLDS', () => {
+  it('has defined threshold values', () => {
+    expect(HB_THRESHOLDS.rushYardsRank).toBe(10)
+    expect(HB_THRESHOLDS.defenseRushRank).toBe(22)
+    expect(HB_THRESHOLDS.minCarries).toBe(80)
+  })
+})
+
+describe('checkHbThresholds', () => {
+  const NOW = Date.now()
+
+  it('returns finding for elite rusher vs bad defense', () => {
+    const hbData = {
+      name: 'Derrick Henry',
+      team: 'BAL',
+      rush_yards: 1200,
+      rush_yards_rank: 2,
+      carries: 250,
+    }
+    const defenseData = {
+      team: 'TEN',
+      rush_defense_rank: 28,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkHbThresholds(hbData, defenseData, context)
+
+    expect(findings.length).toBeGreaterThan(0)
+    expect(findings[0].agent).toBe('hb')
+    expect(findings[0].type).toBe('hb_volume_advantage')
+  })
+
+  it('returns YPC efficiency finding', () => {
+    const hbData = {
+      name: 'Saquon Barkley',
+      team: 'PHI',
+      yards_per_carry: 5.8,
+      yards_per_carry_rank: 3,
+      carries: 200,
+    }
+    const defenseData = {
+      team: 'NYG',
+      rush_yards_allowed_rank: 25,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkHbThresholds(hbData, defenseData, context)
+
+    expect(findings.length).toBe(1)
+    expect(findings[0].type).toBe('hb_efficiency_advantage')
+  })
+
+  it('returns TD opportunity finding', () => {
+    const hbData = {
+      name: 'Josh Jacobs',
+      team: 'GB',
+      rush_tds: 12,
+      rush_td_rank: 4,
+      carries: 180,
+    }
+    const defenseData = {
+      team: 'CHI',
+      rush_td_allowed_rank: 26,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkHbThresholds(hbData, defenseData, context)
+
+    expect(findings.length).toBe(1)
+    expect(findings[0].type).toBe('hb_td_opportunity')
+  })
+
+  it('returns receiving back finding', () => {
+    const hbData = {
+      name: 'Christian McCaffrey',
+      team: 'SF',
+      receptions: 65,
+      reception_rank: 2,
+      carries: 200,
+    }
+    const defenseData = {
+      team: 'SEA',
+      rush_defense_rank: 15,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkHbThresholds(hbData, defenseData, context)
+
+    expect(findings.length).toBe(1)
+    expect(findings[0].type).toBe('hb_receiving_factor')
+  })
+
+  it('returns empty when sample size too small', () => {
+    const hbData = {
+      name: 'Backup RB',
+      team: 'CAR',
+      rush_yards: 200,
+      rush_yards_rank: 5,
+      carries: 40, // Too few
+    }
+    const defenseData = {
+      team: 'ATL',
+      rush_defense_rank: 30,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkHbThresholds(hbData, defenseData, context)
+
+    expect(findings.filter(f => f.type === 'hb_volume_advantage').length).toBe(0)
+  })
+
+  it('returns multiple findings for complete back', () => {
+    const hbData = {
+      name: 'CMC',
+      team: 'SF',
+      rush_yards: 1100,
+      rush_yards_rank: 3,
+      yards_per_carry: 5.2,
+      yards_per_carry_rank: 5,
+      rush_tds: 10,
+      rush_td_rank: 6,
+      reception_rank: 1,
+      carries: 220,
+    }
+    const defenseData = {
+      team: 'ARI',
+      rush_defense_rank: 28,
+      rush_yards_allowed_rank: 26,
+      rush_td_allowed_rank: 24,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkHbThresholds(hbData, defenseData, context)
+
+    expect(findings.length).toBe(4)
+    expect(findings.map(f => f.type)).toContain('hb_volume_advantage')
+    expect(findings.map(f => f.type)).toContain('hb_efficiency_advantage')
+    expect(findings.map(f => f.type)).toContain('hb_td_opportunity')
+    expect(findings.map(f => f.type)).toContain('hb_receiving_factor')
+  })
+})

--- a/__tests__/terminal/agents/pressure.test.ts
+++ b/__tests__/terminal/agents/pressure.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import { PRESSURE_THRESHOLDS, checkPressureThresholds } from '@/lib/terminal/agents/pressure/thresholds'
+
+describe('PRESSURE_THRESHOLDS', () => {
+  it('has defined threshold values', () => {
+    expect(PRESSURE_THRESHOLDS.pressureRateRank).toBe(10)
+    expect(PRESSURE_THRESHOLDS.passBlockWinRateRank).toBe(22)
+    expect(PRESSURE_THRESHOLDS.qbPressuredRatingThreshold).toBe(60)
+  })
+})
+
+describe('checkPressureThresholds', () => {
+  const NOW = Date.now()
+
+  it('returns finding when pressure mismatch exists', () => {
+    const defenseData = {
+      team: 'SF',
+      pressure_rate: 42,
+      pressure_rate_rank: 3,
+    }
+    const offenseData = {
+      team: 'SEA',
+      qb_name: 'Sam Darnold',
+      pass_block_win_rate_rank: 28,
+      qb_passer_rating_under_pressure: 31.2,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkPressureThresholds(defenseData, offenseData, context)
+
+    expect(findings.length).toBeGreaterThan(0)
+    expect(findings[0].agent).toBe('pressure')
+    expect(findings[0].type).toBe('pressure_rate_advantage')
+    expect(findings[0].value_num).toBe(3)
+  })
+
+  it('returns QB vulnerability finding when pressure mismatch and bad rating', () => {
+    const defenseData = {
+      team: 'SF',
+      pressure_rate: 42,
+      pressure_rate_rank: 3,
+    }
+    const offenseData = {
+      team: 'SEA',
+      qb_name: 'Sam Darnold',
+      pass_block_win_rate_rank: 28,
+      qb_passer_rating_under_pressure: 31.2, // Below 60 threshold
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkPressureThresholds(defenseData, offenseData, context)
+
+    expect(findings.length).toBe(2)
+    expect(findings.map(f => f.type)).toContain('pressure_rate_advantage')
+    expect(findings.map(f => f.type)).toContain('qb_pressure_vulnerability')
+  })
+
+  it('returns empty when defense pressure rank not elite', () => {
+    const defenseData = {
+      team: 'CHI',
+      pressure_rate: 28,
+      pressure_rate_rank: 20, // Not elite
+    }
+    const offenseData = {
+      team: 'DET',
+      qb_name: 'Jared Goff',
+      pass_block_win_rate_rank: 28,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkPressureThresholds(defenseData, offenseData, context)
+
+    expect(findings.length).toBe(0)
+  })
+
+  it('returns empty when OL not vulnerable', () => {
+    const defenseData = {
+      team: 'SF',
+      pressure_rate: 42,
+      pressure_rate_rank: 3,
+    }
+    const offenseData = {
+      team: 'PHI',
+      qb_name: 'Jalen Hurts',
+      pass_block_win_rate_rank: 5, // Elite OL
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkPressureThresholds(defenseData, offenseData, context)
+
+    expect(findings.length).toBe(0)
+  })
+
+  it('returns only pressure finding when QB handles pressure well', () => {
+    const defenseData = {
+      team: 'SF',
+      pressure_rate: 42,
+      pressure_rate_rank: 3,
+    }
+    const offenseData = {
+      team: 'KC',
+      qb_name: 'Patrick Mahomes',
+      pass_block_win_rate_rank: 25,
+      qb_passer_rating_under_pressure: 85.0, // Handles pressure well
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkPressureThresholds(defenseData, offenseData, context)
+
+    expect(findings.length).toBe(1)
+    expect(findings[0].type).toBe('pressure_rate_advantage')
+  })
+
+  it('generates correct source reference', () => {
+    const defenseData = {
+      team: 'SF',
+      pressure_rate: 42,
+      pressure_rate_rank: 3,
+    }
+    const offenseData = {
+      team: 'SEA',
+      qb_name: 'Geno Smith',
+      pass_block_win_rate_rank: 28,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkPressureThresholds(defenseData, offenseData, context)
+
+    expect(findings[0].source_ref).toBe('local://data/pressure/2025-week-20.json')
+    expect(findings[0].source_type).toBe('local')
+    expect(findings[0].source_timestamp).toBe(NOW)
+  })
+})

--- a/__tests__/terminal/agents/qb.test.ts
+++ b/__tests__/terminal/agents/qb.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest'
+import { QB_THRESHOLDS, checkQbThresholds } from '@/lib/terminal/agents/qb/thresholds'
+
+describe('QB_THRESHOLDS', () => {
+  it('has defined threshold values', () => {
+    expect(QB_THRESHOLDS.qbRatingRank).toBe(10)
+    expect(QB_THRESHOLDS.defensePassRank).toBe(22)
+    expect(QB_THRESHOLDS.minAttempts).toBe(150)
+  })
+})
+
+describe('checkQbThresholds', () => {
+  const NOW = Date.now()
+
+  it('returns finding for elite QB vs bad pass defense', () => {
+    const qbData = {
+      name: 'Josh Allen',
+      team: 'BUF',
+      qb_rating: 108.5,
+      qb_rating_rank: 3,
+      attempts: 400,
+    }
+    const defenseData = {
+      team: 'MIA',
+      pass_defense_rank: 28,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkQbThresholds(qbData, defenseData, context)
+
+    expect(findings.length).toBeGreaterThan(0)
+    expect(findings[0].agent).toBe('qb')
+    expect(findings[0].type).toBe('qb_rating_advantage')
+  })
+
+  it('returns empty when QB not elite', () => {
+    const qbData = {
+      name: 'Average QB',
+      team: 'NYG',
+      qb_rating: 85.0,
+      qb_rating_rank: 18,
+      attempts: 300,
+    }
+    const defenseData = {
+      team: 'DAL',
+      pass_defense_rank: 28,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkQbThresholds(qbData, defenseData, context)
+
+    expect(findings.length).toBe(0)
+  })
+
+  it('returns empty when defense is good', () => {
+    const qbData = {
+      name: 'Patrick Mahomes',
+      team: 'KC',
+      qb_rating: 110.0,
+      qb_rating_rank: 2,
+      attempts: 450,
+    }
+    const defenseData = {
+      team: 'SF',
+      pass_defense_rank: 5, // Good defense
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkQbThresholds(qbData, defenseData, context)
+
+    expect(findings.length).toBe(0)
+  })
+
+  it('returns turnover risk finding', () => {
+    const qbData = {
+      name: 'Jameis Winston',
+      team: 'CLE',
+      turnover_pct: 4.5,
+      turnover_pct_rank: 28,
+      attempts: 200,
+    }
+    const defenseData = {
+      team: 'NE',
+      interception_rate_rank: 3, // Ball-hawking defense
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkQbThresholds(qbData, defenseData, context)
+
+    expect(findings.length).toBe(1)
+    expect(findings[0].type).toBe('qb_turnover_risk')
+  })
+
+  it('returns YPA advantage finding', () => {
+    const qbData = {
+      name: 'Lamar Jackson',
+      team: 'BAL',
+      yards_per_attempt: 8.5,
+      yards_per_attempt_rank: 2,
+      attempts: 350,
+    }
+    const defenseData = {
+      team: 'TEN',
+      pass_yards_allowed_rank: 25,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkQbThresholds(qbData, defenseData, context)
+
+    expect(findings.length).toBe(1)
+    expect(findings[0].type).toBe('qb_ypa_advantage')
+  })
+
+  it('returns empty when sample size too small', () => {
+    const qbData = {
+      name: 'Rookie QB',
+      team: 'CAR',
+      qb_rating: 105.0,
+      qb_rating_rank: 5,
+      attempts: 50, // Too few
+    }
+    const defenseData = {
+      team: 'ATL',
+      pass_defense_rank: 30,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkQbThresholds(qbData, defenseData, context)
+
+    expect(findings.length).toBe(0)
+  })
+})

--- a/__tests__/terminal/agents/te.test.ts
+++ b/__tests__/terminal/agents/te.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest'
+import { TE_THRESHOLDS, checkTeThresholds } from '@/lib/terminal/agents/te/thresholds'
+
+describe('TE_THRESHOLDS', () => {
+  it('has defined threshold values', () => {
+    expect(TE_THRESHOLDS.targetShareRank).toBe(8)
+    expect(TE_THRESHOLDS.defenseTeRank).toBe(22)
+    expect(TE_THRESHOLDS.minTargets).toBe(40)
+  })
+})
+
+describe('checkTeThresholds', () => {
+  const NOW = Date.now()
+
+  it('returns finding for elite TE vs bad TE defense', () => {
+    const teData = {
+      name: 'Travis Kelce',
+      team: 'KC',
+      target_share: 22,
+      target_share_rank: 2,
+      targets: 120,
+    }
+    const defenseData = {
+      team: 'LV',
+      te_defense_rank: 28,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkTeThresholds(teData, defenseData, context)
+
+    expect(findings.length).toBeGreaterThan(0)
+    expect(findings[0].agent).toBe('te')
+    expect(findings[0].type).toBe('te_target_volume')
+  })
+
+  it('returns yardage advantage finding', () => {
+    const teData = {
+      name: 'Sam LaPorta',
+      team: 'DET',
+      receiving_yards: 850,
+      receiving_yards_rank: 3,
+      targets: 90,
+    }
+    const defenseData = {
+      team: 'CHI',
+      yards_allowed_to_te_rank: 26,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkTeThresholds(teData, defenseData, context)
+
+    expect(findings.length).toBe(1)
+    expect(findings[0].type).toBe('te_yardage_advantage')
+  })
+
+  it('returns TD opportunity finding', () => {
+    const teData = {
+      name: 'Mark Andrews',
+      team: 'BAL',
+      receiving_tds: 8,
+      receiving_td_rank: 2,
+      targets: 80,
+    }
+    const defenseData = {
+      team: 'CIN',
+      td_allowed_to_te_rank: 24,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkTeThresholds(teData, defenseData, context)
+
+    expect(findings.length).toBe(1)
+    expect(findings[0].type).toBe('te_td_opportunity')
+  })
+
+  it('returns red zone factor finding', () => {
+    const teData = {
+      name: 'George Kittle',
+      team: 'SF',
+      red_zone_targets: 18,
+      red_zone_target_rank: 3,
+      targets: 75,
+    }
+    const defenseData = {
+      team: 'SEA',
+      te_defense_rank: 15,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkTeThresholds(teData, defenseData, context)
+
+    expect(findings.length).toBe(1)
+    expect(findings[0].type).toBe('te_red_zone_factor')
+  })
+
+  it('returns empty when sample size too small', () => {
+    const teData = {
+      name: 'Backup TE',
+      team: 'NYG',
+      target_share: 15,
+      target_share_rank: 5,
+      targets: 20, // Too few
+    }
+    const defenseData = {
+      team: 'DAL',
+      te_defense_rank: 30,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkTeThresholds(teData, defenseData, context)
+
+    expect(findings.filter(f => f.type === 'te_target_volume').length).toBe(0)
+  })
+
+  it('returns multiple findings for elite TE', () => {
+    const teData = {
+      name: 'Travis Kelce',
+      team: 'KC',
+      target_share: 25,
+      target_share_rank: 1,
+      receiving_yards: 950,
+      receiving_yards_rank: 1,
+      receiving_tds: 9,
+      receiving_td_rank: 1,
+      red_zone_target_rank: 2,
+      targets: 130,
+    }
+    const defenseData = {
+      team: 'DEN',
+      te_defense_rank: 26,
+      yards_allowed_to_te_rank: 25,
+      td_allowed_to_te_rank: 28,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkTeThresholds(teData, defenseData, context)
+
+    expect(findings.length).toBe(4)
+    expect(findings.map(f => f.type)).toContain('te_target_volume')
+    expect(findings.map(f => f.type)).toContain('te_yardage_advantage')
+    expect(findings.map(f => f.type)).toContain('te_td_opportunity')
+    expect(findings.map(f => f.type)).toContain('te_red_zone_factor')
+  })
+
+  it('returns empty when defense is good vs TEs', () => {
+    const teData = {
+      name: 'Good TE',
+      team: 'PHI',
+      target_share: 20,
+      target_share_rank: 4,
+      targets: 80,
+    }
+    const defenseData = {
+      team: 'SF',
+      te_defense_rank: 5, // Good defense
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkTeThresholds(teData, defenseData, context)
+
+    expect(findings.length).toBe(0)
+  })
+})

--- a/__tests__/terminal/agents/weather.test.ts
+++ b/__tests__/terminal/agents/weather.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest'
+import { WEATHER_THRESHOLDS, checkWeatherThresholds } from '@/lib/terminal/agents/weather/thresholds'
+
+describe('WEATHER_THRESHOLDS', () => {
+  it('has defined threshold values', () => {
+    expect(WEATHER_THRESHOLDS.windMph).toBe(15)
+    expect(WEATHER_THRESHOLDS.coldTemp).toBe(32)
+    expect(WEATHER_THRESHOLDS.hotTemp).toBe(90)
+    expect(WEATHER_THRESHOLDS.precipitationChance).toBe(50)
+  })
+})
+
+describe('checkWeatherThresholds', () => {
+  const NOW = Date.now()
+
+  it('returns finding for high wind', () => {
+    const weather = {
+      temperature: 45,
+      wind_mph: 18,
+      precipitation_chance: 10,
+      indoor: false,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkWeatherThresholds(weather, context)
+
+    expect(findings.length).toBeGreaterThan(0)
+    expect(findings[0].type).toBe('weather_wind')
+    expect(findings[0].value_num).toBe(18)
+    expect(findings[0].agent).toBe('weather')
+  })
+
+  it('returns empty for indoor games', () => {
+    const weather = {
+      temperature: 72,
+      wind_mph: 0,
+      precipitation_chance: 0,
+      indoor: true,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkWeatherThresholds(weather, context)
+
+    expect(findings.length).toBe(0)
+  })
+
+  it('returns finding for freezing temperature', () => {
+    const weather = {
+      temperature: 28,
+      wind_mph: 5,
+      precipitation_chance: 20,
+      indoor: false,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkWeatherThresholds(weather, context)
+
+    expect(findings.length).toBe(1)
+    expect(findings[0].type).toBe('weather_cold')
+    expect(findings[0].value_num).toBe(28)
+  })
+
+  it('returns finding for high precipitation chance', () => {
+    const weather = {
+      temperature: 55,
+      wind_mph: 8,
+      precipitation_chance: 70,
+      precipitation_type: 'rain' as const,
+      indoor: false,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkWeatherThresholds(weather, context)
+
+    expect(findings.length).toBe(1)
+    expect(findings[0].type).toBe('weather_rain')
+    expect(findings[0].value_num).toBe(70)
+  })
+
+  it('returns multiple findings for harsh conditions', () => {
+    const weather = {
+      temperature: 25,
+      wind_mph: 22,
+      precipitation_chance: 80,
+      precipitation_type: 'snow' as const,
+      indoor: false,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkWeatherThresholds(weather, context)
+
+    expect(findings.length).toBe(3)
+    expect(findings.map(f => f.type)).toContain('weather_wind')
+    expect(findings.map(f => f.type)).toContain('weather_cold')
+    expect(findings.map(f => f.type)).toContain('weather_rain')
+  })
+
+  it('returns empty for mild conditions', () => {
+    const weather = {
+      temperature: 65,
+      wind_mph: 8,
+      precipitation_chance: 10,
+      indoor: false,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkWeatherThresholds(weather, context)
+
+    expect(findings.length).toBe(0)
+  })
+
+  it('returns empty at exactly threshold values (wind)', () => {
+    const weather = {
+      temperature: 65,
+      wind_mph: 14, // Below 15 threshold
+      precipitation_chance: 10,
+      indoor: false,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkWeatherThresholds(weather, context)
+
+    expect(findings.length).toBe(0)
+  })
+
+  it('includes precipitation type in context', () => {
+    const weather = {
+      temperature: 30,
+      wind_mph: 5,
+      precipitation_chance: 60,
+      precipitation_type: 'snow' as const,
+      indoor: false,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkWeatherThresholds(weather, context)
+
+    const precipFinding = findings.find(f => f.type === 'weather_rain')
+    expect(precipFinding?.comparison_context).toContain('snow')
+  })
+})

--- a/__tests__/terminal/agents/wr.test.ts
+++ b/__tests__/terminal/agents/wr.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest'
+import { WR_THRESHOLDS, checkWrThresholds } from '@/lib/terminal/agents/wr/thresholds'
+
+describe('WR_THRESHOLDS', () => {
+  it('has defined threshold values', () => {
+    expect(WR_THRESHOLDS.targetShareRank).toBe(10)
+    expect(WR_THRESHOLDS.defensePassRank).toBe(22)
+    expect(WR_THRESHOLDS.minTargets).toBe(50)
+  })
+})
+
+describe('checkWrThresholds', () => {
+  const NOW = Date.now()
+
+  it('returns finding for high target share vs bad defense', () => {
+    const wrData = {
+      name: 'Ja\'Marr Chase',
+      team: 'CIN',
+      target_share: 28,
+      target_share_rank: 3,
+      targets: 150,
+    }
+    const defenseData = {
+      team: 'CLE',
+      pass_defense_rank: 25,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkWrThresholds(wrData, defenseData, context)
+
+    expect(findings.length).toBeGreaterThan(0)
+    expect(findings[0].agent).toBe('wr')
+    expect(findings[0].type).toBe('wr_target_volume')
+  })
+
+  it('returns yardage advantage finding', () => {
+    const wrData = {
+      name: 'Tyreek Hill',
+      team: 'MIA',
+      receiving_yards: 1400,
+      receiving_yards_rank: 2,
+      targets: 140,
+    }
+    const defenseData = {
+      team: 'NYJ',
+      yards_allowed_to_wr_rank: 26,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkWrThresholds(wrData, defenseData, context)
+
+    expect(findings.length).toBe(1)
+    expect(findings[0].type).toBe('wr_yardage_advantage')
+  })
+
+  it('returns TD opportunity finding', () => {
+    const wrData = {
+      name: 'Davante Adams',
+      team: 'NYJ',
+      receiving_tds: 10,
+      receiving_td_rank: 4,
+      targets: 100,
+    }
+    const defenseData = {
+      team: 'NE',
+      td_allowed_to_wr_rank: 24,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkWrThresholds(wrData, defenseData, context)
+
+    expect(findings.length).toBe(1)
+    expect(findings[0].type).toBe('wr_td_opportunity')
+  })
+
+  it('returns separation finding', () => {
+    const wrData = {
+      name: 'CeeDee Lamb',
+      team: 'DAL',
+      separation: 3.2,
+      separation_rank: 2,
+      targets: 160,
+    }
+    const defenseData = {
+      team: 'PHI',
+      pass_defense_rank: 10,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkWrThresholds(wrData, defenseData, context)
+
+    expect(findings.length).toBe(1)
+    expect(findings[0].type).toBe('wr_separation_advantage')
+  })
+
+  it('returns empty when sample size too small', () => {
+    const wrData = {
+      name: 'Rookie WR',
+      team: 'CAR',
+      target_share: 20,
+      target_share_rank: 5,
+      targets: 30, // Too few
+    }
+    const defenseData = {
+      team: 'ATL',
+      pass_defense_rank: 30,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkWrThresholds(wrData, defenseData, context)
+
+    expect(findings.filter(f => f.type === 'wr_target_volume').length).toBe(0)
+  })
+
+  it('returns multiple findings for elite WR', () => {
+    const wrData = {
+      name: 'Amon-Ra St. Brown',
+      team: 'DET',
+      target_share: 26,
+      target_share_rank: 5,
+      receiving_yards: 1200,
+      receiving_yards_rank: 6,
+      receiving_tds: 9,
+      receiving_td_rank: 8,
+      separation_rank: 4,
+      targets: 145,
+    }
+    const defenseData = {
+      team: 'GB',
+      pass_defense_rank: 24,
+      yards_allowed_to_wr_rank: 23,
+      td_allowed_to_wr_rank: 25,
+    }
+    const context = {
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkWrThresholds(wrData, defenseData, context)
+
+    expect(findings.length).toBe(4)
+    expect(findings.map(f => f.type)).toContain('wr_target_volume')
+    expect(findings.map(f => f.type)).toContain('wr_yardage_advantage')
+    expect(findings.map(f => f.type)).toContain('wr_td_opportunity')
+    expect(findings.map(f => f.type)).toContain('wr_separation_advantage')
+  })
+})

--- a/__tests__/terminal/analyst/analyst.test.ts
+++ b/__tests__/terminal/analyst/analyst.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildAnalystPrompt,
+  parseLLMOutput,
+  loadRelevantSkillMds,
+} from '@/lib/terminal/analyst'
+import type { Finding, LLMOutput, ClaimParts } from '@/lib/terminal/schemas'
+
+const NOW = Date.now()
+
+const mockFindings: Finding[] = [
+  {
+    id: 'epa-jsn-recv-123',
+    agent: 'epa',
+    type: 'receiving_epa_mismatch',
+    stat: 'receiving_epa_rank',
+    value_num: 3,
+    value_type: 'numeric',
+    threshold_met: 'rank <= 10 AND opponent allows top 10',
+    comparison_context: '3rd in league vs 8th worst defense',
+    source_ref: 'local://data/epa/2025-week-20.json',
+    source_type: 'local',
+    source_timestamp: NOW,
+  },
+  {
+    id: 'pressure-sf-vs-sea-456',
+    agent: 'pressure',
+    type: 'pressure_rate_advantage',
+    stat: 'pressure_rate_rank',
+    value_num: 3,
+    value_type: 'numeric',
+    threshold_met: 'defense rank <= 10 AND OL rank >= 22',
+    comparison_context: '3rd pass rush vs 28th OL',
+    source_ref: 'local://data/pressure/2025-week-20.json',
+    source_type: 'local',
+    source_timestamp: NOW,
+  },
+]
+
+// Valid ClaimParts following the schema
+const validClaimParts: ClaimParts = {
+  metrics: ['receiving_epa'],
+  direction: 'positive',
+  comparator: 'ranks',
+  rank_or_percentile: {
+    type: 'rank',
+    value: 3,
+    scope: 'league',
+    direction: 'top',
+  },
+}
+
+describe('buildAnalystPrompt', () => {
+  it('includes skill MDs in prompt', () => {
+    const skillMds = {
+      epa: '# EPA Agent\n\nFocus on efficiency.',
+      pressure: '# Pressure Agent\n\nFocus on pass rush.',
+    }
+
+    const prompt = buildAnalystPrompt(mockFindings, skillMds)
+
+    expect(prompt).toContain('EPA Agent')
+    expect(prompt).toContain('Pressure Agent')
+    expect(prompt).toContain('Focus on efficiency')
+  })
+
+  it('includes findings JSON in prompt', () => {
+    const prompt = buildAnalystPrompt(mockFindings, {})
+
+    expect(prompt).toContain('epa-jsn-recv-123')
+    expect(prompt).toContain('receiving_epa_mismatch')
+    expect(prompt).toContain('pressure_rate_advantage')
+  })
+
+  it('includes output format instructions', () => {
+    const prompt = buildAnalystPrompt(mockFindings, {})
+
+    expect(prompt).toContain('severity')
+    expect(prompt).toContain('claim_parts')
+    expect(prompt).toContain('implications')
+    expect(prompt).toContain('suppressions')
+    expect(prompt).toContain('metrics')
+  })
+
+  it('includes valid implication lists per agent', () => {
+    const prompt = buildAnalystPrompt(mockFindings, {})
+
+    expect(prompt).toContain('EPA: wr_receptions_over')
+    expect(prompt).toContain('PRESSURE: qb_sacks_over')
+  })
+})
+
+describe('parseLLMOutput', () => {
+  it('parses valid JSON output', () => {
+    const raw = JSON.stringify({
+      'epa-jsn-recv-123': {
+        severity: 'high',
+        claim_parts: validClaimParts,
+        implications: ['wr_yards_over'],
+        suppressions: [],
+      },
+    })
+
+    const { output, errors } = parseLLMOutput(raw, mockFindings)
+
+    expect(output['epa-jsn-recv-123']).toBeDefined()
+    expect(output['epa-jsn-recv-123'].severity).toBe('high')
+    expect(errors.filter(e => !e.includes('Invalid implications'))).toHaveLength(0)
+  })
+
+  it('handles markdown code blocks', () => {
+    const raw = `\`\`\`json
+{
+  "epa-jsn-recv-123": {
+    "severity": "medium",
+    "claim_parts": ${JSON.stringify(validClaimParts)},
+    "implications": ["wr_receptions_over"],
+    "suppressions": []
+  }
+}
+\`\`\``
+
+    const { output } = parseLLMOutput(raw, mockFindings)
+
+    expect(output['epa-jsn-recv-123']).toBeDefined()
+    expect(output['epa-jsn-recv-123'].severity).toBe('medium')
+  })
+
+  it('reports error for invalid JSON', () => {
+    const raw = 'not valid json'
+
+    const { output, errors } = parseLLMOutput(raw, mockFindings)
+
+    expect(errors.length).toBeGreaterThan(0)
+    expect(errors[0]).toContain('Failed to parse')
+  })
+
+  it('reports error for unknown finding_id', () => {
+    const raw = JSON.stringify({
+      'unknown-finding-id': {
+        severity: 'high',
+        claim_parts: validClaimParts,
+        implications: [],
+        suppressions: [],
+      },
+    })
+
+    const { errors } = parseLLMOutput(raw, mockFindings)
+
+    expect(errors).toContain('Unknown finding_id: unknown-finding-id')
+  })
+
+  it('reports error for invalid severity', () => {
+    const raw = JSON.stringify({
+      'epa-jsn-recv-123': {
+        severity: 'critical', // Should be 'high' or 'medium'
+        claim_parts: validClaimParts,
+        implications: [],
+        suppressions: [],
+      },
+    })
+
+    const { errors } = parseLLMOutput(raw, mockFindings)
+
+    expect(errors.some(e => e.includes('Invalid severity'))).toBe(true)
+  })
+
+  it('reports error for missing claim_parts metrics', () => {
+    const raw = JSON.stringify({
+      'epa-jsn-recv-123': {
+        severity: 'high',
+        claim_parts: {
+          // Missing metrics array
+          direction: 'positive',
+          comparator: 'ranks',
+        },
+        implications: [],
+        suppressions: [],
+      },
+    })
+
+    const { errors } = parseLLMOutput(raw, mockFindings)
+
+    expect(errors.some(e => e.includes('Missing or invalid claim_parts'))).toBe(true)
+  })
+
+  it('reports error for invalid implications', () => {
+    const raw = JSON.stringify({
+      'epa-jsn-recv-123': {
+        severity: 'high',
+        claim_parts: validClaimParts,
+        implications: ['qb_sacks_over'], // Invalid for EPA agent
+        suppressions: [],
+      },
+    })
+
+    const { errors } = parseLLMOutput(raw, mockFindings)
+
+    expect(errors.some(e => e.includes('Invalid implications'))).toBe(true)
+  })
+
+  it('filters out invalid implications from output', () => {
+    const raw = JSON.stringify({
+      'epa-jsn-recv-123': {
+        severity: 'high',
+        claim_parts: validClaimParts,
+        implications: ['wr_yards_over', 'qb_sacks_over'], // qb_sacks_over invalid for EPA
+        suppressions: [],
+      },
+    })
+
+    const { output } = parseLLMOutput(raw, mockFindings)
+
+    expect(output['epa-jsn-recv-123'].implications).toContain('wr_yards_over')
+    expect(output['epa-jsn-recv-123'].implications).not.toContain('qb_sacks_over')
+  })
+})
+
+describe('loadRelevantSkillMds', () => {
+  it('loads skill MDs for agents in findings', () => {
+    const skillMds = loadRelevantSkillMds(mockFindings)
+
+    expect(Object.keys(skillMds)).toContain('epa')
+    expect(Object.keys(skillMds)).toContain('pressure')
+  })
+
+  it('returns unique agents only', () => {
+    const duplicateFinding: Finding = {
+      ...mockFindings[0],
+      id: 'epa-another-789',
+    }
+
+    const skillMds = loadRelevantSkillMds([...mockFindings, duplicateFinding])
+
+    // Should still only have 2 agents (epa, pressure)
+    expect(Object.keys(skillMds).length).toBe(2)
+  })
+
+  it('returns content for each agent skill.md', () => {
+    const skillMds = loadRelevantSkillMds(mockFindings)
+
+    // EPA skill.md should contain domain info
+    expect(skillMds.epa).toContain('EPA')
+    expect(skillMds.pressure).toContain('Pressure')
+  })
+})

--- a/__tests__/terminal/confidence.test.ts
+++ b/__tests__/terminal/confidence.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calculateConfidence,
+  confidenceInputsFromFinding,
+  calculateFindingConfidence,
+  type ConfidenceInputs,
+} from '@/lib/terminal/engine/confidence'
+import type { Finding } from '@/lib/terminal/schemas'
+
+const NOW = Date.now()
+const ONE_HOUR = 60 * 60 * 1000
+const ONE_DAY = 24 * ONE_HOUR
+const ONE_WEEK = 7 * ONE_DAY
+
+describe('calculateConfidence', () => {
+  it('returns baseline 0.5 with minimal inputs', () => {
+    const inputs: ConfidenceInputs = {
+      evidenceCount: 1,
+      hasLocalSource: false,
+      hasWebSource: false,
+      webSourceAge: null,
+      localDataAge: 0,
+      sampleSize: null,
+      hasLineEvidence: false,
+      lineAge: null,
+    }
+    expect(calculateConfidence(inputs)).toBeCloseTo(0.5, 2)
+  })
+
+  it('increases with multiple evidence (+0.15 for 3+)', () => {
+    const inputs: ConfidenceInputs = {
+      evidenceCount: 3,
+      hasLocalSource: false,
+      hasWebSource: false,
+      webSourceAge: null,
+      localDataAge: 0,
+      sampleSize: null,
+      hasLineEvidence: false,
+      lineAge: null,
+    }
+    expect(calculateConfidence(inputs)).toBeCloseTo(0.65, 2)
+  })
+
+  it('increases with local source (+0.10)', () => {
+    const inputs: ConfidenceInputs = {
+      evidenceCount: 1,
+      hasLocalSource: true,
+      hasWebSource: false,
+      webSourceAge: null,
+      localDataAge: 0,
+      sampleSize: null,
+      hasLineEvidence: false,
+      lineAge: null,
+    }
+    expect(calculateConfidence(inputs)).toBeCloseTo(0.6, 2)
+  })
+
+  it('increases with fresh web source (+0.08)', () => {
+    const inputs: ConfidenceInputs = {
+      evidenceCount: 1,
+      hasLocalSource: false,
+      hasWebSource: true,
+      webSourceAge: ONE_HOUR, // 1 hour old - fresh
+      localDataAge: 0,
+      sampleSize: null,
+      hasLineEvidence: false,
+      lineAge: null,
+    }
+    expect(calculateConfidence(inputs)).toBeCloseTo(0.58, 2)
+  })
+
+  it('no bonus for stale web source (> 4 hours)', () => {
+    const inputs: ConfidenceInputs = {
+      evidenceCount: 1,
+      hasLocalSource: false,
+      hasWebSource: true,
+      webSourceAge: 5 * ONE_HOUR, // 5 hours old - stale
+      localDataAge: 0,
+      sampleSize: null,
+      hasLineEvidence: false,
+      lineAge: null,
+    }
+    expect(calculateConfidence(inputs)).toBeCloseTo(0.5, 2)
+  })
+
+  it('increases with large sample size (+0.12 for 100+)', () => {
+    const inputs: ConfidenceInputs = {
+      evidenceCount: 1,
+      hasLocalSource: false,
+      hasWebSource: false,
+      webSourceAge: null,
+      localDataAge: 0,
+      sampleSize: 150,
+      hasLineEvidence: false,
+      lineAge: null,
+    }
+    expect(calculateConfidence(inputs)).toBeCloseTo(0.62, 2)
+  })
+
+  it('penalizes small sample size (-0.10 for < 50)', () => {
+    const inputs: ConfidenceInputs = {
+      evidenceCount: 1,
+      hasLocalSource: false,
+      hasWebSource: false,
+      webSourceAge: null,
+      localDataAge: 0,
+      sampleSize: 25,
+      hasLineEvidence: false,
+      lineAge: null,
+    }
+    expect(calculateConfidence(inputs)).toBeCloseTo(0.4, 2)
+  })
+
+  it('increases with fresh line evidence (+0.10 for < 30 min)', () => {
+    const inputs: ConfidenceInputs = {
+      evidenceCount: 1,
+      hasLocalSource: false,
+      hasWebSource: false,
+      webSourceAge: null,
+      localDataAge: 0,
+      sampleSize: null,
+      hasLineEvidence: true,
+      lineAge: 10 * 60 * 1000, // 10 min
+    }
+    expect(calculateConfidence(inputs)).toBeCloseTo(0.6, 2)
+  })
+
+  it('penalizes stale line evidence (-0.15 for > 2 hours)', () => {
+    const inputs: ConfidenceInputs = {
+      evidenceCount: 1,
+      hasLocalSource: false,
+      hasWebSource: false,
+      webSourceAge: null,
+      localDataAge: 0,
+      sampleSize: null,
+      hasLineEvidence: true,
+      lineAge: 3 * ONE_HOUR, // 3 hours
+    }
+    expect(calculateConfidence(inputs)).toBeCloseTo(0.35, 2)
+  })
+
+  it('penalizes stale local data (-0.20 for > 7 days)', () => {
+    const inputs: ConfidenceInputs = {
+      evidenceCount: 1,
+      hasLocalSource: true,
+      hasWebSource: false,
+      webSourceAge: null,
+      localDataAge: 10 * ONE_DAY, // 10 days
+      sampleSize: null,
+      hasLineEvidence: false,
+      lineAge: null,
+    }
+    // 0.5 + 0.10 (local) - 0.20 (stale) = 0.40
+    expect(calculateConfidence(inputs)).toBeCloseTo(0.4, 2)
+  })
+
+  it('clamps to [0, 1] range', () => {
+    const highInputs: ConfidenceInputs = {
+      evidenceCount: 5,
+      hasLocalSource: true,
+      hasWebSource: true,
+      webSourceAge: 1000,
+      localDataAge: 0,
+      sampleSize: 200,
+      hasLineEvidence: true,
+      lineAge: 1000,
+    }
+    expect(calculateConfidence(highInputs)).toBeLessThanOrEqual(1)
+    expect(calculateConfidence(highInputs)).toBeGreaterThanOrEqual(0)
+
+    const lowInputs: ConfidenceInputs = {
+      evidenceCount: 1,
+      hasLocalSource: false,
+      hasWebSource: false,
+      webSourceAge: null,
+      localDataAge: 30 * ONE_DAY,
+      sampleSize: 10,
+      hasLineEvidence: true,
+      lineAge: 10 * ONE_HOUR,
+    }
+    expect(calculateConfidence(lowInputs)).toBeGreaterThanOrEqual(0)
+  })
+
+  it('stacks bonuses correctly', () => {
+    const inputs: ConfidenceInputs = {
+      evidenceCount: 3,      // +0.15
+      hasLocalSource: true,  // +0.10
+      hasWebSource: false,
+      webSourceAge: null,
+      localDataAge: ONE_DAY, // no penalty
+      sampleSize: 100,       // +0.12
+      hasLineEvidence: false,
+      lineAge: null,
+    }
+    // 0.5 + 0.15 + 0.10 + 0.12 = 0.87
+    expect(calculateConfidence(inputs)).toBeCloseTo(0.87, 2)
+  })
+})
+
+describe('confidenceInputsFromFinding', () => {
+  it('builds inputs from local finding', () => {
+    const finding: Finding = {
+      id: 'test-001',
+      agent: 'epa',
+      type: 'receiving_epa_mismatch',
+      stat: 'receiving_epa',
+      value_num: 0.31,
+      value_type: 'numeric',
+      threshold_met: 'rank <= 10',
+      comparison_context: 'top 5',
+      source_ref: 'local://data/epa/week-20.json',
+      source_type: 'local',
+      source_timestamp: NOW - 2 * ONE_DAY,
+    }
+
+    const inputs = confidenceInputsFromFinding(finding)
+
+    expect(inputs.hasLocalSource).toBe(true)
+    expect(inputs.hasWebSource).toBe(false)
+    expect(inputs.evidenceCount).toBe(1)
+    expect(inputs.localDataAge).toBeGreaterThan(0)
+  })
+
+  it('builds inputs from web finding', () => {
+    const finding: Finding = {
+      id: 'test-002',
+      agent: 'pressure',
+      type: 'pressure_rate_advantage',
+      stat: 'pressure_rate',
+      value_num: 42,
+      value_type: 'numeric',
+      threshold_met: 'rate >= 40%',
+      comparison_context: 'top 3',
+      source_ref: 'https://example.com/stats',
+      source_type: 'web',
+      source_timestamp: NOW - ONE_HOUR,
+      quote_snippet: 'SF generates 42% pressure rate',
+    }
+
+    const inputs = confidenceInputsFromFinding(finding)
+
+    expect(inputs.hasLocalSource).toBe(false)
+    expect(inputs.hasWebSource).toBe(true)
+    expect(inputs.webSourceAge).toBeGreaterThan(0)
+  })
+})
+
+describe('calculateFindingConfidence', () => {
+  it('calculates confidence for a finding', () => {
+    const finding: Finding = {
+      id: 'test-001',
+      agent: 'epa',
+      type: 'receiving_epa_mismatch',
+      stat: 'receiving_epa',
+      value_num: 0.31,
+      value_type: 'numeric',
+      threshold_met: 'rank <= 10',
+      comparison_context: 'top 5',
+      source_ref: 'local://data/epa/week-20.json',
+      source_type: 'local',
+      source_timestamp: NOW - 2 * ONE_DAY,
+    }
+
+    const confidence = calculateFindingConfidence(finding)
+
+    // 0.5 base + 0.10 local source = 0.60
+    expect(confidence).toBeCloseTo(0.6, 2)
+  })
+
+  it('includes sample size if provided', () => {
+    const finding: Finding = {
+      id: 'test-001',
+      agent: 'epa',
+      type: 'receiving_epa_mismatch',
+      stat: 'receiving_epa',
+      value_num: 0.31,
+      value_type: 'numeric',
+      threshold_met: 'rank <= 10',
+      comparison_context: 'top 5',
+      source_ref: 'local://data/epa/week-20.json',
+      source_type: 'local',
+      source_timestamp: NOW - 2 * ONE_DAY,
+    }
+
+    const confidence = calculateFindingConfidence(finding, { sampleSize: 120 })
+
+    // 0.5 base + 0.10 local + 0.12 sample = 0.72
+    expect(confidence).toBeCloseTo(0.72, 2)
+  })
+})

--- a/__tests__/terminal/engine/agent-runner.test.ts
+++ b/__tests__/terminal/engine/agent-runner.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest'
+import { runAgents, type MatchupContext } from '@/lib/terminal/engine/agent-runner'
+
+describe('runAgents', () => {
+  const NOW = Date.now()
+
+  it('aggregates findings from EPA agent', async () => {
+    const context: MatchupContext = {
+      homeTeam: 'SEA',
+      awayTeam: 'SF',
+      players: {
+        SEA: [
+          {
+            name: 'Jaxon Smith-Njigba',
+            team: 'SEA',
+            position: 'WR',
+            receiving_epa_rank: 3,
+            targets: 120,
+          },
+        ],
+        SF: [],
+      },
+      teamStats: {
+        SEA: {},
+        SF: { epa_allowed_to_wr_rank: 8 },
+      },
+      weather: { temperature: 55, wind_mph: 8, precipitation_chance: 10, indoor: false },
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const result = await runAgents(context)
+
+    expect(result.findings.length).toBeGreaterThan(0)
+    expect(result.findings.some(f => f.agent === 'epa')).toBe(true)
+    expect(result.agentsInvoked).toContain('epa')
+  })
+
+  it('aggregates findings from pressure agent', async () => {
+    const context: MatchupContext = {
+      homeTeam: 'SEA',
+      awayTeam: 'SF',
+      players: {
+        SEA: [],
+        SF: [],
+      },
+      teamStats: {
+        SEA: { pass_block_win_rate_rank: 28, qb_name: 'Geno Smith' },
+        SF: { pressure_rate_rank: 3, pressure_rate: 42 },
+      },
+      weather: { temperature: 55, wind_mph: 8, precipitation_chance: 10, indoor: false },
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const result = await runAgents(context)
+
+    expect(result.findings.some(f => f.agent === 'pressure')).toBe(true)
+    expect(result.agentsInvoked).toContain('pressure')
+  })
+
+  it('aggregates findings from weather agent', async () => {
+    const context: MatchupContext = {
+      homeTeam: 'GB',
+      awayTeam: 'CHI',
+      players: { GB: [], CHI: [] },
+      teamStats: { GB: {}, CHI: {} },
+      weather: { temperature: 28, wind_mph: 22, precipitation_chance: 60, indoor: false },
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const result = await runAgents(context)
+
+    expect(result.findings.some(f => f.agent === 'weather')).toBe(true)
+    expect(result.agentsInvoked).toContain('weather')
+  })
+
+  it('returns empty findings for indoor game with no matchup advantages', async () => {
+    const context: MatchupContext = {
+      homeTeam: 'DAL',
+      awayTeam: 'NYG',
+      players: { DAL: [], NYG: [] },
+      teamStats: { DAL: {}, NYG: {} },
+      weather: { temperature: 72, wind_mph: 0, precipitation_chance: 0, indoor: true },
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const result = await runAgents(context)
+
+    // Weather should not trigger for indoor
+    expect(result.findings.filter(f => f.agent === 'weather').length).toBe(0)
+    expect(result.agentsSilent).toContain('weather')
+  })
+
+  it('tracks silent agents correctly', async () => {
+    const context: MatchupContext = {
+      homeTeam: 'TEN',
+      awayTeam: 'JAX',
+      players: { TEN: [], JAX: [] },
+      teamStats: { TEN: {}, JAX: {} },
+      weather: { temperature: 65, wind_mph: 5, precipitation_chance: 10, indoor: false },
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const result = await runAgents(context)
+
+    // All agents should be silent with no data
+    expect(result.agentsSilent).toContain('epa')
+    expect(result.agentsSilent).toContain('pressure')
+    expect(result.agentsSilent).toContain('weather')
+    expect(result.agentsSilent).toContain('qb')
+    expect(result.agentsSilent).toContain('hb')
+    expect(result.agentsSilent).toContain('wr')
+    expect(result.agentsSilent).toContain('te')
+  })
+
+  it('aggregates from multiple agents simultaneously', async () => {
+    const context: MatchupContext = {
+      homeTeam: 'KC',
+      awayTeam: 'LV',
+      players: {
+        KC: [
+          {
+            name: 'Travis Kelce',
+            team: 'KC',
+            position: 'TE',
+            target_share_rank: 2,
+            receiving_yards_rank: 1,
+            targets: 120,
+          },
+          {
+            name: 'Patrick Mahomes',
+            team: 'KC',
+            position: 'QB',
+            qb_rating_rank: 2,
+            attempts: 400,
+          },
+        ],
+        LV: [],
+      },
+      teamStats: {
+        KC: {},
+        LV: {
+          te_defense_rank: 28,
+          yards_allowed_to_te_rank: 25,
+          pass_defense_rank: 26,
+        },
+      },
+      weather: { temperature: 45, wind_mph: 18, precipitation_chance: 20, indoor: false },
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const result = await runAgents(context)
+
+    expect(result.findings.length).toBeGreaterThan(2)
+    // Should have weather (wind), TE, and QB findings
+    expect(result.agentsInvoked.length).toBeGreaterThan(1)
+  })
+
+  it('includes all required fields in result', async () => {
+    const context: MatchupContext = {
+      homeTeam: 'MIN',
+      awayTeam: 'DET',
+      players: { MIN: [], DET: [] },
+      teamStats: { MIN: {}, DET: {} },
+      weather: { temperature: 72, wind_mph: 0, precipitation_chance: 0, indoor: true },
+      dataTimestamp: NOW,
+      dataVersion: '2025-week-20',
+    }
+
+    const result = await runAgents(context)
+
+    expect(result).toHaveProperty('findings')
+    expect(result).toHaveProperty('agentsInvoked')
+    expect(result).toHaveProperty('agentsSilent')
+    expect(Array.isArray(result.findings)).toBe(true)
+    expect(Array.isArray(result.agentsInvoked)).toBe(true)
+    expect(Array.isArray(result.agentsSilent)).toBe(true)
+  })
+})

--- a/__tests__/terminal/golden-fixtures.test.ts
+++ b/__tests__/terminal/golden-fixtures.test.ts
@@ -1,0 +1,612 @@
+/**
+ * Golden Test Fixtures
+ *
+ * Tests the full pipeline: Finding → LLM Output → Alert assembly → Validation
+ * with explicit pass/fail matrix for each validator rule.
+ */
+import { describe, it, expect, beforeAll } from 'vitest'
+import {
+  FindingSchema,
+  AlertSchema,
+  LLMOutputSchema,
+  LLMFindingOutputSchema,
+  EvidenceSchema,
+  SourceSchema,
+  assembleAlerts,
+  buildCodeDerivedFields,
+  validateImplicationsForAgent,
+  isLineEvidence,
+  type Finding,
+  type LLMOutput,
+  type Alert,
+  type AgentType,
+} from '@/lib/terminal/schemas'
+
+// =============================================================================
+// FIXTURES: One Finding per agent
+// =============================================================================
+
+const NOW = Date.now()
+const ONE_HOUR = 60 * 60 * 1000
+const ONE_DAY = 24 * ONE_HOUR
+const ONE_WEEK = 7 * ONE_DAY
+
+const GOLDEN_FINDINGS: Finding[] = [
+  {
+    id: 'epa-jsn-recv-001',
+    agent: 'epa',
+    type: 'receiving_epa_mismatch',
+    stat: 'receiving_epa_rank',
+    value_num: 3,
+    value_type: 'numeric',
+    threshold_met: 'rank <= 10',
+    comparison_context: '3rd in league',
+    source_ref: 'local://data/epa/week-20.json',
+    source_type: 'local',
+    source_timestamp: NOW - 2 * ONE_DAY,
+  },
+  {
+    id: 'pressure-sf-sea-001',
+    agent: 'pressure',
+    type: 'pressure_rate_advantage',
+    stat: 'pressure_rate_rank',
+    value_num: 3,
+    value_type: 'numeric',
+    threshold_met: 'rank <= 10',
+    comparison_context: '3rd best pass rush',
+    source_ref: 'local://data/pressure/week-20.json',
+    source_type: 'local',
+    source_timestamp: NOW - 2 * ONE_DAY,
+  },
+  {
+    id: 'weather-wind-001',
+    agent: 'weather',
+    type: 'weather_wind',
+    stat: 'wind_mph',
+    value_num: 18,
+    value_type: 'numeric',
+    threshold_met: 'wind >= 15 mph',
+    comparison_context: '18 mph crosswind',
+    source_ref: 'local://data/weather/week-20.json',
+    source_type: 'local',
+    source_timestamp: NOW - 4 * ONE_HOUR,
+  },
+  {
+    id: 'qb-darnold-pressure-001',
+    agent: 'qb',
+    type: 'qb_pressure_vulnerability',
+    stat: 'qb_passer_rating_under_pressure',
+    value_num: 31.2,
+    value_type: 'numeric',
+    threshold_met: 'rating < 60',
+    comparison_context: '31.2 passer rating when pressured',
+    source_ref: 'local://data/qb/week-20.json',
+    source_type: 'local',
+    source_timestamp: NOW - 2 * ONE_DAY,
+  },
+  {
+    id: 'hb-cmc-workload-001',
+    agent: 'hb',
+    type: 'rb_workload_increase',
+    stat: 'rushing_epa_rank',
+    value_num: 2,
+    value_type: 'numeric',
+    threshold_met: 'rank <= 5',
+    comparison_context: '2nd in rushing EPA',
+    source_ref: 'local://data/rb/week-20.json',
+    source_type: 'local',
+    source_timestamp: NOW - 2 * ONE_DAY,
+  },
+  {
+    id: 'wr-jsn-target-001',
+    agent: 'wr',
+    type: 'wr_target_share',
+    stat: 'target_share',
+    value_num: 28.5,
+    value_type: 'numeric',
+    threshold_met: 'share >= 25%',
+    comparison_context: '28.5% target share',
+    source_ref: 'local://data/wr/week-20.json',
+    source_type: 'local',
+    source_timestamp: NOW - 2 * ONE_DAY,
+  },
+  {
+    id: 'te-kittle-rz-001',
+    agent: 'te',
+    type: 'te_red_zone_role',
+    stat: 'red_zone_targets',
+    value_num: 12,
+    value_type: 'numeric',
+    threshold_met: 'targets >= 10',
+    comparison_context: '12 red zone targets',
+    source_ref: 'local://data/te/week-20.json',
+    source_type: 'local',
+    source_timestamp: NOW - 2 * ONE_DAY,
+  },
+]
+
+// Valid LLM output for golden findings
+const GOLDEN_LLM_OUTPUT: LLMOutput = {
+  'epa-jsn-recv-001': {
+    severity: 'high',
+    claim_parts: {
+      metrics: ['receiving_epa', 'target_share'],
+      direction: 'positive',
+      comparator: 'ranks',
+      rank_or_percentile: { type: 'rank', value: 3, scope: 'league', direction: 'top' },
+      comparison_target: 'opponent_average',
+    },
+    implications: ['wr_receptions_over', 'wr_yards_over'],
+    suppressions: [],
+  },
+  'pressure-sf-sea-001': {
+    severity: 'high',
+    claim_parts: {
+      metrics: ['pressure_rate'],
+      direction: 'positive',
+      comparator: 'ranks',
+      rank_or_percentile: { type: 'rank', value: 3, scope: 'league', direction: 'top' },
+    },
+    implications: ['qb_sacks_over', 'qb_ints_over'],
+    suppressions: [],
+  },
+  'weather-wind-001': {
+    severity: 'medium',
+    claim_parts: {
+      metrics: ['pass_block_win_rate'], // Using as proxy for weather impact
+      direction: 'negative',
+      comparator: 'trails',
+    },
+    implications: ['game_total_under'],
+    suppressions: ['indoor_stadium'],
+  },
+  'qb-darnold-pressure-001': {
+    severity: 'high',
+    claim_parts: {
+      metrics: ['passer_rating'],
+      direction: 'negative',
+      comparator: 'trails',
+      comparison_target: 'league_average',
+    },
+    implications: ['qb_ints_over', 'qb_pass_yards_under'],
+    suppressions: [],
+  },
+  'hb-cmc-workload-001': {
+    severity: 'high',
+    claim_parts: {
+      metrics: ['rushing_epa'],
+      direction: 'positive',
+      comparator: 'ranks',
+      rank_or_percentile: { type: 'rank', value: 2, scope: 'league', direction: 'top' },
+    },
+    implications: ['rb_rush_yards_over', 'rb_tds_over'],
+    suppressions: [],
+  },
+  'wr-jsn-target-001': {
+    severity: 'high',
+    claim_parts: {
+      metrics: ['target_share'],
+      direction: 'positive',
+      comparator: 'exceeds',
+      comparison_target: 'position_average',
+    },
+    implications: ['wr_receptions_over', 'wr_yards_over'],
+    suppressions: [],
+  },
+  'te-kittle-rz-001': {
+    severity: 'medium',
+    claim_parts: {
+      metrics: ['red_zone_targets'],
+      direction: 'positive',
+      comparator: 'exceeds',
+      comparison_target: 'position_average',
+    },
+    implications: ['te_receptions_over', 'te_tds_over'],
+    suppressions: [],
+  },
+}
+
+// =============================================================================
+// SCHEMA VALIDATION TESTS
+// =============================================================================
+
+describe('Schema Validation', () => {
+  describe('FindingSchema', () => {
+    it('validates all golden findings', () => {
+      for (const finding of GOLDEN_FINDINGS) {
+        expect(() => FindingSchema.parse(finding)).not.toThrow()
+      }
+    })
+
+    it('rejects extra fields (strict mode)', () => {
+      const badFinding = { ...GOLDEN_FINDINGS[0], extraField: 'should fail' }
+      expect(() => FindingSchema.parse(badFinding)).toThrow()
+    })
+  })
+
+  describe('LLMOutputSchema', () => {
+    it('validates golden LLM output', () => {
+      expect(() => LLMOutputSchema.parse(GOLDEN_LLM_OUTPUT)).not.toThrow()
+    })
+
+    it('rejects extra fields in finding output (strict mode)', () => {
+      const badOutput = {
+        ...GOLDEN_LLM_OUTPUT,
+        'epa-jsn-recv-001': {
+          ...GOLDEN_LLM_OUTPUT['epa-jsn-recv-001'],
+          confidence: 0.8, // LLM cannot set confidence
+        },
+      }
+      expect(() => LLMOutputSchema.parse(badOutput)).toThrow()
+    })
+
+    it('rejects empty output', () => {
+      expect(() => LLMOutputSchema.parse({})).toThrow()
+    })
+  })
+
+  describe('EvidenceSchema (discriminated union)', () => {
+    it('accepts local evidence', () => {
+      const localEvidence = {
+        stat: 'receiving_epa',
+        value_num: 0.31,
+        value_type: 'numeric' as const,
+        comparison: 'top 5',
+        source_type: 'local' as const,
+        source_ref: 'local://data/epa/week-20.json',
+      }
+      expect(() => EvidenceSchema.parse(localEvidence)).not.toThrow()
+    })
+
+    it('accepts web evidence with required quote_snippet', () => {
+      const webEvidence = {
+        stat: 'pressure_rate',
+        value_num: 42,
+        value_type: 'numeric' as const,
+        comparison: 'top 3',
+        source_type: 'web' as const,
+        source_ref: 'https://example.com/stats',
+        quote_snippet: 'SF generates 42% pressure rate',
+      }
+      expect(() => EvidenceSchema.parse(webEvidence)).not.toThrow()
+    })
+
+    it('rejects web evidence without quote_snippet', () => {
+      const badWebEvidence = {
+        stat: 'pressure_rate',
+        value_num: 42,
+        value_type: 'numeric' as const,
+        comparison: 'top 3',
+        source_type: 'web' as const,
+        source_ref: 'https://example.com/stats',
+        // missing quote_snippet
+      }
+      expect(() => EvidenceSchema.parse(badWebEvidence)).toThrow()
+    })
+
+    it('accepts line evidence with all required fields', () => {
+      const lineEvidence = {
+        stat: 'spread',
+        value_num: -3.5,
+        value_type: 'numeric' as const,
+        comparison: 'current line',
+        source_type: 'line' as const,
+        source_ref: 'https://sportsbook.com',
+        line_type: 'spread' as const,
+        line_value: -3.5,
+        line_odds: -110,
+        book: 'DraftKings',
+        line_timestamp: NOW - 5 * 60 * 1000,
+        line_ttl: 30 * 60 * 1000,
+      }
+      expect(() => EvidenceSchema.parse(lineEvidence)).not.toThrow()
+    })
+
+    it('rejects line evidence missing line_type', () => {
+      const badLineEvidence = {
+        stat: 'spread',
+        value_num: -3.5,
+        value_type: 'numeric' as const,
+        comparison: 'current line',
+        source_type: 'line' as const,
+        source_ref: 'https://sportsbook.com',
+        // missing line_type and other required fields
+      }
+      expect(() => EvidenceSchema.parse(badLineEvidence)).toThrow()
+    })
+  })
+})
+
+// =============================================================================
+// ALERT ASSEMBLY TESTS
+// =============================================================================
+
+describe('Alert Assembly', () => {
+  it('assembles alerts from findings and LLM output', () => {
+    const confidences = new Map(GOLDEN_FINDINGS.map(f => [f.id, 0.75]))
+    const alerts = assembleAlerts(GOLDEN_FINDINGS, GOLDEN_LLM_OUTPUT, confidences, '2025-week-20')
+
+    expect(alerts).toHaveLength(GOLDEN_FINDINGS.length)
+
+    for (const alert of alerts) {
+      expect(() => AlertSchema.parse(alert)).not.toThrow()
+    }
+  })
+
+  it('throws on missing LLM output for a finding', () => {
+    const partialLLMOutput = { ...GOLDEN_LLM_OUTPUT }
+    delete partialLLMOutput['epa-jsn-recv-001']
+
+    const confidences = new Map(GOLDEN_FINDINGS.map(f => [f.id, 0.75]))
+
+    expect(() =>
+      assembleAlerts(GOLDEN_FINDINGS, partialLLMOutput, confidences, '2025-week-20')
+    ).toThrow(/missing for finding/)
+  })
+
+  it('throws on extra LLM output for unknown finding', () => {
+    const extraLLMOutput: LLMOutput = {
+      ...GOLDEN_LLM_OUTPUT,
+      'unknown-finding-id': {
+        severity: 'high',
+        claim_parts: {
+          metrics: ['receiving_epa'],
+          direction: 'positive',
+          comparator: 'ranks',
+        },
+        implications: ['wr_receptions_over'],
+        suppressions: [],
+      },
+    }
+
+    const confidences = new Map(GOLDEN_FINDINGS.map(f => [f.id, 0.75]))
+
+    expect(() =>
+      assembleAlerts(GOLDEN_FINDINGS, extraLLMOutput, confidences, '2025-week-20')
+    ).toThrow(/unknown finding_id/)
+  })
+
+  it('preserves code-derived fields immutably', () => {
+    const confidences = new Map([['epa-jsn-recv-001', 0.82]])
+    const alerts = assembleAlerts(
+      [GOLDEN_FINDINGS[0]],
+      { 'epa-jsn-recv-001': GOLDEN_LLM_OUTPUT['epa-jsn-recv-001'] },
+      confidences,
+      '2025-week-20'
+    )
+
+    const alert = alerts[0]
+
+    // These should come from code, not LLM
+    expect(alert.id).toBe('epa-jsn-recv-001')
+    expect(alert.agent).toBe('epa')
+    expect(alert.confidence).toBe(0.82)
+    expect(alert.evidence).toHaveLength(1)
+    expect(alert.sources).toHaveLength(1)
+  })
+})
+
+// =============================================================================
+// VALIDATOR PASS/FAIL MATRIX
+// =============================================================================
+
+describe('Validator Pass/Fail Matrix', () => {
+  describe('Missing Evidence', () => {
+    it('FAIL: Alert with empty evidence array', () => {
+      const badAlert = {
+        id: 'test-001',
+        agent: 'epa' as const,
+        evidence: [], // Empty - should fail
+        sources: [{ type: 'local' as const, ref: 'local://test', data_version: 'v1', data_timestamp: NOW }],
+        confidence: 0.75,
+        freshness: 'weekly' as const,
+        severity: 'high' as const,
+        claim: 'test claim',
+        implications: ['wr_receptions_over' as const],
+        suppressions: [],
+      }
+      expect(() => AlertSchema.parse(badAlert)).toThrow()
+    })
+  })
+
+  describe('Orphan Source', () => {
+    it('PASS: All sources match evidence refs', () => {
+      const goodAlert = buildValidAlert()
+      expect(() => AlertSchema.parse(goodAlert)).not.toThrow()
+      // Additional validator would check source/evidence ref matching
+    })
+
+    // Note: Full orphan source validation requires custom validator (Task 2)
+  })
+
+  describe('Edge Language Without LineEvidence', () => {
+    it('PASS: Normal claim without edge language', () => {
+      const normalClaim = 'Receiving EPA ranks top 5 in league'
+      expect(normalClaim).not.toMatch(/edge|value|mispriced|exploit|sharp|lock/i)
+    })
+
+    it('FAIL: Edge language detected', () => {
+      const edgeClaims = [
+        'This is a clear edge',
+        'Great value on this line',
+        'The spread is mispriced',
+        'Time to exploit this matchup',
+        'Sharp money is on the over',
+        'This is a lock',
+      ]
+      for (const claim of edgeClaims) {
+        expect(claim).toMatch(/edge|value|mispriced|exploit|sharp|lock/i)
+      }
+    })
+  })
+
+  describe('Stale Line Evidence', () => {
+    const LINE_TTL = {
+      spread: 30 * 60 * 1000,
+      total: 30 * 60 * 1000,
+      prop: 15 * 60 * 1000,
+      moneyline: 60 * 60 * 1000,
+    }
+
+    it('PASS: Fresh spread line (< 30 min)', () => {
+      const freshLine = {
+        stat: 'spread',
+        value_num: -3.5,
+        value_type: 'numeric' as const,
+        comparison: 'current',
+        source_type: 'line' as const,
+        source_ref: 'https://book.com',
+        line_type: 'spread' as const,
+        line_value: -3.5,
+        line_odds: -110,
+        book: 'DK',
+        line_timestamp: NOW - 10 * 60 * 1000, // 10 min ago
+        line_ttl: LINE_TTL.spread,
+      }
+      const age = NOW - freshLine.line_timestamp
+      expect(age).toBeLessThan(LINE_TTL.spread)
+    })
+
+    it('FAIL: Stale spread line (> 30 min)', () => {
+      const staleLine = {
+        stat: 'spread',
+        value_num: -3.5,
+        value_type: 'numeric' as const,
+        comparison: 'current',
+        source_type: 'line' as const,
+        source_ref: 'https://book.com',
+        line_type: 'spread' as const,
+        line_value: -3.5,
+        line_odds: -110,
+        book: 'DK',
+        line_timestamp: NOW - 60 * 60 * 1000, // 60 min ago
+        line_ttl: LINE_TTL.spread,
+      }
+      const age = NOW - staleLine.line_timestamp
+      expect(age).toBeGreaterThan(LINE_TTL.spread)
+    })
+
+    it('FAIL: Stale prop line (> 15 min)', () => {
+      const staleProp = {
+        line_type: 'prop' as const,
+        line_timestamp: NOW - 20 * 60 * 1000, // 20 min ago
+        line_ttl: LINE_TTL.prop,
+      }
+      const age = NOW - staleProp.line_timestamp
+      expect(age).toBeGreaterThan(LINE_TTL.prop)
+    })
+  })
+
+  describe('Extra JSON Fields (Strict Mode)', () => {
+    it('FAIL: Finding with extra field', () => {
+      const badFinding = {
+        ...GOLDEN_FINDINGS[0],
+        secretField: 'should not be here',
+      }
+      expect(() => FindingSchema.parse(badFinding)).toThrow()
+    })
+
+    it('FAIL: Alert with extra field', () => {
+      const baseAlert = buildValidAlert()
+      const badAlert = { ...baseAlert, hackedField: true }
+      expect(() => AlertSchema.parse(badAlert)).toThrow()
+    })
+
+    it('FAIL: Evidence with extra field', () => {
+      const badEvidence = {
+        stat: 'receiving_epa',
+        value_num: 0.31,
+        value_type: 'numeric' as const,
+        comparison: 'top 5',
+        source_type: 'local' as const,
+        source_ref: 'local://test',
+        injectedField: 'attack',
+      }
+      expect(() => EvidenceSchema.parse(badEvidence)).toThrow()
+    })
+
+    it('FAIL: Source with extra field', () => {
+      const badSource = {
+        type: 'local' as const,
+        ref: 'local://test',
+        data_version: 'v1',
+        data_timestamp: NOW,
+        malicious: true,
+      }
+      expect(() => SourceSchema.parse(badSource)).toThrow()
+    })
+
+    it('FAIL: LLM output with extra field per finding', () => {
+      const badLLMOutput = {
+        'test-finding': {
+          severity: 'high' as const,
+          claim_parts: {
+            metrics: ['receiving_epa' as const],
+            direction: 'positive' as const,
+            comparator: 'ranks' as const,
+          },
+          implications: ['wr_receptions_over' as const],
+          suppressions: [],
+          confidence: 0.9, // LLM trying to set confidence
+        },
+      }
+      expect(() => LLMOutputSchema.parse(badLLMOutput)).toThrow()
+    })
+  })
+
+  describe('Implications Allowlist Per Agent', () => {
+    it('PASS: EPA agent with valid implications', () => {
+      const result = validateImplicationsForAgent('epa', ['wr_receptions_over', 'wr_yards_over'])
+      expect(result.valid).toBe(true)
+      expect(result.invalid).toHaveLength(0)
+    })
+
+    it('FAIL: EPA agent with pressure implication', () => {
+      const result = validateImplicationsForAgent('epa', ['qb_sacks_over'])
+      expect(result.valid).toBe(false)
+      expect(result.invalid).toContain('qb_sacks_over')
+    })
+
+    it('FAIL: Weather agent with QB implication', () => {
+      const result = validateImplicationsForAgent('weather', ['qb_pass_tds_over'])
+      expect(result.valid).toBe(false)
+      expect(result.invalid).toContain('qb_pass_tds_over')
+    })
+
+    it('PASS: Pressure agent with valid implications', () => {
+      const result = validateImplicationsForAgent('pressure', ['qb_sacks_over', 'qb_ints_over'])
+      expect(result.valid).toBe(true)
+    })
+  })
+})
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+function buildValidAlert(): Alert {
+  return {
+    id: 'test-valid-001',
+    agent: 'epa',
+    evidence: [{
+      stat: 'receiving_epa',
+      value_num: 0.31,
+      value_type: 'numeric',
+      comparison: 'top 5 in league',
+      source_type: 'local',
+      source_ref: 'local://data/epa/week-20.json',
+    }],
+    sources: [{
+      type: 'local',
+      ref: 'local://data/epa/week-20.json',
+      data_version: '2025-week-20',
+      data_timestamp: NOW - 2 * ONE_DAY,
+    }],
+    confidence: 0.75,
+    freshness: 'weekly',
+    severity: 'high',
+    claim: 'Receiving EPA ranks top 5 in league',
+    implications: ['wr_receptions_over', 'wr_yards_over'],
+    suppressions: [],
+  }
+}

--- a/__tests__/terminal/provenance.test.ts
+++ b/__tests__/terminal/provenance.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect } from 'vitest'
+import {
+  hashContent,
+  hashObject,
+  buildProvenance,
+  verifyProvenance,
+  generateRequestId,
+} from '@/lib/terminal/engine/provenance'
+import type { Finding } from '@/lib/terminal/schemas'
+
+const NOW = Date.now()
+
+describe('hashContent', () => {
+  it('produces consistent hashes', () => {
+    const content = 'test content'
+    const hash1 = hashContent(content)
+    const hash2 = hashContent(content)
+    expect(hash1).toBe(hash2)
+  })
+
+  it('produces different hashes for different content', () => {
+    const hash1 = hashContent('content A')
+    const hash2 = hashContent('content B')
+    expect(hash1).not.toBe(hash2)
+  })
+
+  it('returns 12-character hash', () => {
+    const hash = hashContent('test')
+    expect(hash).toHaveLength(12)
+  })
+
+  it('produces hex characters only', () => {
+    const hash = hashContent('any content')
+    expect(hash).toMatch(/^[0-9a-f]{12}$/)
+  })
+})
+
+describe('hashObject', () => {
+  it('produces consistent hashes regardless of key order', () => {
+    const obj1 = { b: 2, a: 1, c: 3 }
+    const obj2 = { a: 1, b: 2, c: 3 }
+    expect(hashObject(obj1)).toBe(hashObject(obj2))
+  })
+
+  it('produces different hashes for different objects', () => {
+    const obj1 = { a: 1 }
+    const obj2 = { a: 2 }
+    expect(hashObject(obj1)).not.toBe(hashObject(obj2))
+  })
+})
+
+describe('buildProvenance', () => {
+  const mockFindings: Finding[] = [
+    {
+      id: 'epa-001',
+      agent: 'epa',
+      type: 'receiving_epa_mismatch',
+      stat: 'receiving_epa',
+      value_num: 0.31,
+      value_type: 'numeric',
+      threshold_met: 'rank <= 10',
+      comparison_context: 'top 5',
+      source_ref: 'local://data/epa/week-20.json',
+      source_type: 'local',
+      source_timestamp: NOW,
+    },
+  ]
+
+  it('builds complete provenance object', () => {
+    const provenance = buildProvenance({
+      requestId: 'req-123',
+      prompt: 'Analyze these findings...',
+      skillMds: { epa: '# EPA Agent\nFocus on efficiency.' },
+      findings: mockFindings,
+      dataVersion: '2025-week-20',
+      dataTimestamp: NOW,
+      searchTimestamps: [],
+      agentsInvoked: ['epa'],
+      agentsSilent: ['weather', 'pressure'],
+      cacheHits: 1,
+      cacheMisses: 0,
+      llmModel: 'gpt-4o',
+      llmTemperature: 0,
+    })
+
+    expect(provenance.request_id).toBe('req-123')
+    expect(provenance.prompt_hash).toHaveLength(12)
+    expect(provenance.findings_hash).toHaveLength(12)
+    expect(provenance.skill_md_hashes.epa).toHaveLength(12)
+    expect(provenance.data_version).toBe('2025-week-20')
+    expect(provenance.agents_invoked).toContain('epa')
+    expect(provenance.agents_silent).toContain('weather')
+    expect(provenance.llm_model).toBe('gpt-4o')
+    expect(provenance.llm_temperature).toBe(0)
+  })
+
+  it('produces deterministic hashes', () => {
+    const input = {
+      requestId: 'req-123',
+      prompt: 'test prompt',
+      skillMds: { epa: '# EPA' },
+      findings: mockFindings,
+      dataVersion: '2025-week-20',
+      dataTimestamp: NOW,
+      searchTimestamps: [],
+      agentsInvoked: ['epa'] as const,
+      agentsSilent: [] as const,
+      cacheHits: 0,
+      cacheMisses: 0,
+      llmModel: 'gpt-4o',
+      llmTemperature: 0,
+    }
+
+    const prov1 = buildProvenance(input)
+    const prov2 = buildProvenance(input)
+
+    expect(prov1.prompt_hash).toBe(prov2.prompt_hash)
+    expect(prov1.findings_hash).toBe(prov2.findings_hash)
+    expect(prov1.skill_md_hashes.epa).toBe(prov2.skill_md_hashes.epa)
+  })
+})
+
+describe('verifyProvenance', () => {
+  const mockFindings: Finding[] = [
+    {
+      id: 'epa-001',
+      agent: 'epa',
+      type: 'receiving_epa_mismatch',
+      stat: 'receiving_epa',
+      value_num: 0.31,
+      value_type: 'numeric',
+      threshold_met: 'rank <= 10',
+      comparison_context: 'top 5',
+      source_ref: 'local://data/epa/week-20.json',
+      source_type: 'local',
+      source_timestamp: NOW,
+    },
+  ]
+
+  it('returns valid when hashes match', () => {
+    const prompt = 'test prompt'
+    const skillMds = { epa: '# EPA Agent' }
+
+    const provenance = buildProvenance({
+      requestId: 'req-123',
+      prompt,
+      skillMds,
+      findings: mockFindings,
+      dataVersion: '2025-week-20',
+      dataTimestamp: NOW,
+      searchTimestamps: [],
+      agentsInvoked: ['epa'],
+      agentsSilent: [],
+      cacheHits: 0,
+      cacheMisses: 0,
+      llmModel: 'gpt-4o',
+      llmTemperature: 0,
+    })
+
+    const result = verifyProvenance(provenance, {
+      prompt,
+      skillMds,
+      findings: mockFindings,
+    })
+
+    expect(result.valid).toBe(true)
+    expect(result.mismatches).toHaveLength(0)
+  })
+
+  it('detects prompt hash mismatch', () => {
+    const provenance = buildProvenance({
+      requestId: 'req-123',
+      prompt: 'original prompt',
+      skillMds: {},
+      findings: mockFindings,
+      dataVersion: '2025-week-20',
+      dataTimestamp: NOW,
+      searchTimestamps: [],
+      agentsInvoked: ['epa'],
+      agentsSilent: [],
+      cacheHits: 0,
+      cacheMisses: 0,
+      llmModel: 'gpt-4o',
+      llmTemperature: 0,
+    })
+
+    const result = verifyProvenance(provenance, {
+      prompt: 'different prompt',
+      skillMds: {},
+      findings: mockFindings,
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.mismatches).toHaveLength(1)
+    expect(result.mismatches[0]).toContain('prompt_hash')
+  })
+
+  it('detects findings hash mismatch', () => {
+    const provenance = buildProvenance({
+      requestId: 'req-123',
+      prompt: 'test',
+      skillMds: {},
+      findings: mockFindings,
+      dataVersion: '2025-week-20',
+      dataTimestamp: NOW,
+      searchTimestamps: [],
+      agentsInvoked: ['epa'],
+      agentsSilent: [],
+      cacheHits: 0,
+      cacheMisses: 0,
+      llmModel: 'gpt-4o',
+      llmTemperature: 0,
+    })
+
+    const modifiedFindings = [{ ...mockFindings[0], value_num: 0.99 }]
+
+    const result = verifyProvenance(provenance, {
+      prompt: 'test',
+      skillMds: {},
+      findings: modifiedFindings,
+    })
+
+    expect(result.valid).toBe(false)
+    expect(result.mismatches).toHaveLength(1)
+    expect(result.mismatches[0]).toContain('findings_hash')
+  })
+})
+
+describe('generateRequestId', () => {
+  it('generates unique IDs', () => {
+    const ids = new Set<string>()
+    for (let i = 0; i < 100; i++) {
+      ids.add(generateRequestId())
+    }
+    expect(ids.size).toBe(100)
+  })
+
+  it('starts with req- prefix', () => {
+    const id = generateRequestId()
+    expect(id).toMatch(/^req-/)
+  })
+})

--- a/__tests__/terminal/schemas/ladder.test.ts
+++ b/__tests__/terminal/schemas/ladder.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect } from 'vitest'
+import {
+  RungSchema,
+  RiskTierSchema,
+  LadderSchema,
+  BetResultSchema,
+  organizeLadders,
+} from '@/lib/terminal/schemas'
+
+describe('RungSchema', () => {
+  it('validates a valid rung', () => {
+    const rung = {
+      alert_id: 'epa-chase-recv-123',
+      market: 'Jamar Chase Over 85.5 Receiving Yards',
+      line: 85.5,
+      implied_probability: 0.55,
+      agent: 'epa',
+      rationale: 'Top-3 EPA receiver vs bottom-10 pass defense',
+    }
+
+    const result = RungSchema.safeParse(rung)
+    expect(result.success).toBe(true)
+  })
+
+  it('allows optional line and implied_probability', () => {
+    const rung = {
+      alert_id: 'pressure-sf-456',
+      market: 'Nick Bosa 1+ Sacks',
+      agent: 'pressure',
+      rationale: 'Elite pass rusher vs weak OL',
+    }
+
+    const result = RungSchema.safeParse(rung)
+    expect(result.success).toBe(true)
+  })
+
+  it('enforces rationale max length', () => {
+    const rung = {
+      alert_id: 'test-123',
+      market: 'Test Market',
+      agent: 'epa',
+      rationale: 'A'.repeat(201), // Over 200 char limit
+    }
+
+    const result = RungSchema.safeParse(rung)
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects extra properties (strict mode)', () => {
+    const rung = {
+      alert_id: 'test-123',
+      market: 'Test Market',
+      agent: 'epa',
+      rationale: 'Test rationale',
+      extra_field: 'not allowed',
+    }
+
+    const result = RungSchema.safeParse(rung)
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('RiskTierSchema', () => {
+  it('accepts valid risk tiers', () => {
+    const tiers = ['safe', 'moderate', 'aggressive']
+
+    for (const tier of tiers) {
+      const result = RiskTierSchema.safeParse(tier)
+      expect(result.success).toBe(true)
+    }
+  })
+
+  it('rejects invalid risk tier', () => {
+    const result = RiskTierSchema.safeParse('risky')
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('LadderSchema', () => {
+  it('validates a valid ladder', () => {
+    const ladder = {
+      id: 'ladder-safe-123',
+      name: 'High Confidence Picks',
+      tier: 'safe',
+      rungs: [
+        {
+          alert_id: 'epa-chase-123',
+          market: 'Jamar Chase Over 85.5 Yards',
+          agent: 'epa',
+          rationale: 'Elite efficiency',
+        },
+        {
+          alert_id: 'pressure-sf-456',
+          market: 'Nick Bosa 1+ Sacks',
+          agent: 'pressure',
+          rationale: 'Top pass rusher',
+        },
+      ],
+      total_implied_probability: 0.65,
+      recommended_stake_pct: 3,
+      provenance_hash: 'abc123',
+    }
+
+    const result = LadderSchema.safeParse(ladder)
+    expect(result.success).toBe(true)
+  })
+
+  it('requires at least 1 rung', () => {
+    const ladder = {
+      id: 'ladder-empty',
+      name: 'Empty Ladder',
+      tier: 'safe',
+      rungs: [],
+      provenance_hash: 'abc123',
+    }
+
+    const result = LadderSchema.safeParse(ladder)
+    expect(result.success).toBe(false)
+  })
+
+  it('allows max 5 rungs', () => {
+    const ladder = {
+      id: 'ladder-full',
+      name: 'Full Ladder',
+      tier: 'moderate',
+      rungs: [
+        { alert_id: 'r1', market: 'M1', agent: 'epa', rationale: 'R1' },
+        { alert_id: 'r2', market: 'M2', agent: 'pressure', rationale: 'R2' },
+        { alert_id: 'r3', market: 'M3', agent: 'qb', rationale: 'R3' },
+        { alert_id: 'r4', market: 'M4', agent: 'hb', rationale: 'R4' },
+        { alert_id: 'r5', market: 'M5', agent: 'wr', rationale: 'R5' },
+      ],
+      provenance_hash: 'abc123',
+    }
+
+    const result = LadderSchema.safeParse(ladder)
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects more than 5 rungs', () => {
+    const ladder = {
+      id: 'ladder-overflow',
+      name: 'Too Many Rungs',
+      tier: 'aggressive',
+      rungs: [
+        { alert_id: 'r1', market: 'M1', agent: 'epa', rationale: 'R1' },
+        { alert_id: 'r2', market: 'M2', agent: 'pressure', rationale: 'R2' },
+        { alert_id: 'r3', market: 'M3', agent: 'qb', rationale: 'R3' },
+        { alert_id: 'r4', market: 'M4', agent: 'hb', rationale: 'R4' },
+        { alert_id: 'r5', market: 'M5', agent: 'wr', rationale: 'R5' },
+        { alert_id: 'r6', market: 'M6', agent: 'te', rationale: 'R6' },
+      ],
+      provenance_hash: 'abc123',
+    }
+
+    const result = LadderSchema.safeParse(ladder)
+    expect(result.success).toBe(false)
+  })
+
+  it('validates stake percentage bounds', () => {
+    const ladder = {
+      id: 'ladder-stake',
+      name: 'Test Stake',
+      tier: 'safe',
+      rungs: [{ alert_id: 'r1', market: 'M1', agent: 'epa', rationale: 'R1' }],
+      recommended_stake_pct: 150, // Over 100%
+      provenance_hash: 'abc123',
+    }
+
+    const result = LadderSchema.safeParse(ladder)
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('BetResultSchema', () => {
+  it('validates a valid bet result', () => {
+    const result = {
+      request_id: 'req-bet-123',
+      ladders: [
+        {
+          id: 'ladder-1',
+          name: 'Safe Picks',
+          tier: 'safe',
+          rungs: [
+            { alert_id: 'a1', market: 'M1', agent: 'epa', rationale: 'High confidence' },
+          ],
+          provenance_hash: 'h1',
+        },
+      ],
+      alerts_used: ['a1'],
+      alerts_excluded: ['a2', 'a3'],
+      bet_timestamp: Date.now(),
+      provenance_hash: 'bet-hash',
+    }
+
+    const parsed = BetResultSchema.safeParse(result)
+    expect(parsed.success).toBe(true)
+  })
+
+  it('allows empty ladders array', () => {
+    const result = {
+      request_id: 'req-123',
+      ladders: [],
+      alerts_used: [],
+      alerts_excluded: ['all-excluded'],
+      bet_timestamp: Date.now(),
+      provenance_hash: 'hash',
+    }
+
+    const parsed = BetResultSchema.safeParse(result)
+    expect(parsed.success).toBe(true)
+  })
+})
+
+describe('organizeLadders', () => {
+  it('creates safe tier for high confidence + high severity', () => {
+    const alertIds = ['a1', 'a2', 'a3']
+    const confidences = new Map([
+      ['a1', 0.8],
+      ['a2', 0.75],
+      ['a3', 0.5],
+    ])
+    const severities = new Map<string, 'high' | 'medium'>([
+      ['a1', 'high'],
+      ['a2', 'high'],
+      ['a3', 'medium'],
+    ])
+
+    const ladders = organizeLadders(alertIds, confidences, severities)
+
+    const safeLadder = ladders.find(l => l.tier === 'safe')
+    expect(safeLadder).toBeDefined()
+    expect(safeLadder!.ids).toContain('a1')
+    expect(safeLadder!.ids).toContain('a2')
+    expect(safeLadder!.ids).not.toContain('a3')
+  })
+
+  it('creates moderate tier for medium confidence or medium severity', () => {
+    const alertIds = ['a1', 'a2']
+    const confidences = new Map([
+      ['a1', 0.6],
+      ['a2', 0.55],
+    ])
+    const severities = new Map<string, 'high' | 'medium'>([
+      ['a1', 'medium'],
+      ['a2', 'high'],
+    ])
+
+    const ladders = organizeLadders(alertIds, confidences, severities)
+
+    const modLadder = ladders.find(l => l.tier === 'moderate')
+    expect(modLadder).toBeDefined()
+  })
+
+  it('creates aggressive tier for low confidence alerts', () => {
+    const alertIds = ['a1', 'a2']
+    const confidences = new Map([
+      ['a1', 0.4],
+      ['a2', 0.35],
+    ])
+    const severities = new Map<string, 'high' | 'medium'>([
+      ['a1', 'medium'],
+      ['a2', 'medium'],
+    ])
+
+    const ladders = organizeLadders(alertIds, confidences, severities)
+
+    const aggLadder = ladders.find(l => l.tier === 'aggressive')
+    expect(aggLadder).toBeDefined()
+    expect(aggLadder!.name).toBe('High Upside Longshots')
+  })
+
+  it('limits safe tier to 3 alerts', () => {
+    const alertIds = ['a1', 'a2', 'a3', 'a4', 'a5']
+    const confidences = new Map(alertIds.map(id => [id, 0.8]))
+    const severities = new Map<string, 'high' | 'medium'>(alertIds.map(id => [id, 'high']))
+
+    const ladders = organizeLadders(alertIds, confidences, severities)
+
+    const safeLadder = ladders.find(l => l.tier === 'safe')
+    expect(safeLadder!.ids.length).toBeLessThanOrEqual(3)
+  })
+
+  it('returns empty array when no alerts qualify', () => {
+    // Confidence below 0.3 doesn't qualify for any tier
+    // And we need to avoid triggering moderate tier via medium severity
+    const alertIds = ['a1']
+    const confidences = new Map([['a1', 0.2]]) // Below 0.3 threshold
+    // Note: medium severity with any confidence triggers moderate tier
+    // So we need high severity but low confidence (doesn't trigger safe)
+    const severities = new Map<string, 'high' | 'medium'>([['a1', 'high']])
+
+    const ladders = organizeLadders(alertIds, confidences, severities)
+
+    // With 0.2 confidence and high severity:
+    // - Not safe (needs >= 0.7 AND high severity)
+    // - Not moderate (needs 0.5-0.7 OR medium severity)
+    // - Not aggressive (needs 0.3-0.5)
+    expect(ladders).toHaveLength(0)
+  })
+})

--- a/__tests__/terminal/schemas/script.test.ts
+++ b/__tests__/terminal/schemas/script.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect } from 'vitest'
+import {
+  LegSchema,
+  CorrelationTypeSchema,
+  ScriptSchema,
+  BuildResultSchema,
+  identifyCorrelations,
+} from '@/lib/terminal/schemas'
+
+describe('LegSchema', () => {
+  it('validates a valid leg', () => {
+    const leg = {
+      alert_id: 'epa-chase-recv-123',
+      market: 'Jamar Chase Over 85.5 Receiving Yards',
+      implied_probability: 0.55,
+      correlation_factor: 0.3,
+      agent: 'epa',
+    }
+
+    const result = LegSchema.safeParse(leg)
+    expect(result.success).toBe(true)
+  })
+
+  it('allows optional fields', () => {
+    const leg = {
+      alert_id: 'pressure-sf-vs-sea-456',
+      market: 'Brock Purdy Under 275.5 Pass Yards',
+      agent: 'pressure',
+    }
+
+    const result = LegSchema.safeParse(leg)
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid agent type', () => {
+    const leg = {
+      alert_id: 'test-123',
+      market: 'Test Market',
+      agent: 'invalid_agent',
+    }
+
+    const result = LegSchema.safeParse(leg)
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects correlation_factor outside bounds', () => {
+    const leg = {
+      alert_id: 'test-123',
+      market: 'Test Market',
+      agent: 'epa',
+      correlation_factor: 1.5, // Must be -1 to 1
+    }
+
+    const result = LegSchema.safeParse(leg)
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('CorrelationTypeSchema', () => {
+  it('accepts valid correlation types', () => {
+    const types = ['game_script', 'player_stack', 'weather_cascade', 'defensive_funnel', 'volume_share']
+
+    for (const type of types) {
+      const result = CorrelationTypeSchema.safeParse(type)
+      expect(result.success).toBe(true)
+    }
+  })
+
+  it('rejects invalid correlation type', () => {
+    const result = CorrelationTypeSchema.safeParse('invalid_type')
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('ScriptSchema', () => {
+  it('validates a valid script', () => {
+    const script = {
+      id: 'script-weather-passing-123',
+      name: 'Weather Impact Passing Stack',
+      legs: [
+        { alert_id: 'weather-chi-123', market: 'Game Total Under 42.5', agent: 'weather' },
+        { alert_id: 'qb-fields-456', market: 'Justin Fields Under 225.5 Pass Yards', agent: 'qb' },
+      ],
+      correlation_type: 'weather_cascade',
+      correlation_explanation: 'High winds reduce passing efficiency and deep ball attempts',
+      combined_confidence: 0.72,
+      risk_level: 'moderate',
+      provenance_hash: 'abc123def456',
+    }
+
+    const result = ScriptSchema.safeParse(script)
+    expect(result.success).toBe(true)
+  })
+
+  it('requires at least 2 legs', () => {
+    const script = {
+      id: 'script-123',
+      name: 'Single Leg Script',
+      legs: [{ alert_id: 'test-123', market: 'Test', agent: 'epa' }],
+      correlation_type: 'game_script',
+      correlation_explanation: 'Test',
+      combined_confidence: 0.5,
+      risk_level: 'conservative',
+      provenance_hash: 'abc123',
+    }
+
+    const result = ScriptSchema.safeParse(script)
+    expect(result.success).toBe(false)
+  })
+
+  it('allows max 6 legs', () => {
+    const script = {
+      id: 'script-123',
+      name: 'Six Leg Script',
+      legs: [
+        { alert_id: 'leg-1', market: 'Market 1', agent: 'epa' },
+        { alert_id: 'leg-2', market: 'Market 2', agent: 'pressure' },
+        { alert_id: 'leg-3', market: 'Market 3', agent: 'qb' },
+        { alert_id: 'leg-4', market: 'Market 4', agent: 'hb' },
+        { alert_id: 'leg-5', market: 'Market 5', agent: 'wr' },
+        { alert_id: 'leg-6', market: 'Market 6', agent: 'te' },
+      ],
+      correlation_type: 'player_stack',
+      correlation_explanation: 'Multi-position stack',
+      combined_confidence: 0.3,
+      risk_level: 'aggressive',
+      provenance_hash: 'abc123',
+    }
+
+    const result = ScriptSchema.safeParse(script)
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects more than 6 legs', () => {
+    const script = {
+      id: 'script-123',
+      name: 'Seven Leg Script',
+      legs: [
+        { alert_id: 'leg-1', market: 'Market 1', agent: 'epa' },
+        { alert_id: 'leg-2', market: 'Market 2', agent: 'pressure' },
+        { alert_id: 'leg-3', market: 'Market 3', agent: 'qb' },
+        { alert_id: 'leg-4', market: 'Market 4', agent: 'hb' },
+        { alert_id: 'leg-5', market: 'Market 5', agent: 'wr' },
+        { alert_id: 'leg-6', market: 'Market 6', agent: 'te' },
+        { alert_id: 'leg-7', market: 'Market 7', agent: 'weather' },
+      ],
+      correlation_type: 'player_stack',
+      correlation_explanation: 'Too many legs',
+      combined_confidence: 0.2,
+      risk_level: 'aggressive',
+      provenance_hash: 'abc123',
+    }
+
+    const result = ScriptSchema.safeParse(script)
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects extra properties (strict mode)', () => {
+    const script = {
+      id: 'script-123',
+      name: 'Test Script',
+      legs: [
+        { alert_id: 'leg-1', market: 'Market 1', agent: 'epa' },
+        { alert_id: 'leg-2', market: 'Market 2', agent: 'pressure' },
+      ],
+      correlation_type: 'game_script',
+      correlation_explanation: 'Test',
+      combined_confidence: 0.5,
+      risk_level: 'moderate',
+      provenance_hash: 'abc123',
+      extra_field: 'should fail', // Not allowed
+    }
+
+    const result = ScriptSchema.safeParse(script)
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('BuildResultSchema', () => {
+  it('validates a valid build result', () => {
+    const result = {
+      request_id: 'req-123456',
+      scripts: [
+        {
+          id: 'script-1',
+          name: 'Weather Stack',
+          legs: [
+            { alert_id: 'weather-123', market: 'Under 42.5', agent: 'weather' },
+            { alert_id: 'qb-456', market: 'Under 225.5 Pass', agent: 'qb' },
+          ],
+          correlation_type: 'weather_cascade',
+          correlation_explanation: 'Wind impact',
+          combined_confidence: 0.65,
+          risk_level: 'moderate',
+          provenance_hash: 'hash1',
+        },
+      ],
+      alerts_used: ['weather-123', 'qb-456'],
+      alerts_excluded: ['epa-789'],
+      build_timestamp: Date.now(),
+      provenance_hash: 'build-hash-abc',
+    }
+
+    const parsed = BuildResultSchema.safeParse(result)
+    expect(parsed.success).toBe(true)
+  })
+
+  it('allows empty scripts array', () => {
+    const result = {
+      request_id: 'req-123',
+      scripts: [],
+      alerts_used: [],
+      alerts_excluded: ['all-alerts-excluded'],
+      build_timestamp: Date.now(),
+      provenance_hash: 'hash',
+    }
+
+    const parsed = BuildResultSchema.safeParse(result)
+    expect(parsed.success).toBe(true)
+  })
+})
+
+describe('identifyCorrelations', () => {
+  it('identifies weather_cascade correlation', () => {
+    const alertIds = ['weather-1', 'qb-1', 'wr-1']
+    const alertAgents = new Map([
+      ['weather-1', 'weather'],
+      ['qb-1', 'qb'],
+      ['wr-1', 'wr'],
+    ])
+
+    const correlations = identifyCorrelations(alertIds, alertAgents, new Map())
+
+    expect(correlations.some(c => c.type === 'weather_cascade')).toBe(true)
+    const weatherCorr = correlations.find(c => c.type === 'weather_cascade')!
+    expect(weatherCorr.ids).toContain('weather-1')
+    expect(weatherCorr.explanation).toContain('Weather')
+  })
+
+  it('identifies defensive_funnel correlation', () => {
+    const alertIds = ['pressure-1', 'qb-1']
+    const alertAgents = new Map([
+      ['pressure-1', 'pressure'],
+      ['qb-1', 'qb'],
+    ])
+
+    const correlations = identifyCorrelations(alertIds, alertAgents, new Map())
+
+    expect(correlations.some(c => c.type === 'defensive_funnel')).toBe(true)
+  })
+
+  it('identifies volume_share correlation with multiple WRs', () => {
+    const alertIds = ['wr-1', 'wr-2', 'wr-3']
+    const alertAgents = new Map([
+      ['wr-1', 'wr'],
+      ['wr-2', 'wr'],
+      ['wr-3', 'wr'],
+    ])
+
+    const correlations = identifyCorrelations(alertIds, alertAgents, new Map())
+
+    expect(correlations.some(c => c.type === 'volume_share')).toBe(true)
+    const volCorr = correlations.find(c => c.type === 'volume_share')!
+    expect(volCorr.ids.length).toBeLessThanOrEqual(3)
+  })
+
+  it('identifies game_script correlation with EPA + HB', () => {
+    const alertIds = ['epa-1', 'hb-1', 'hb-2']
+    const alertAgents = new Map([
+      ['epa-1', 'epa'],
+      ['hb-1', 'hb'],
+      ['hb-2', 'hb'],
+    ])
+
+    const correlations = identifyCorrelations(alertIds, alertAgents, new Map())
+
+    expect(correlations.some(c => c.type === 'game_script')).toBe(true)
+  })
+
+  it('returns empty array when no correlations found', () => {
+    const alertIds = ['te-1']
+    const alertAgents = new Map([['te-1', 'te']])
+
+    const correlations = identifyCorrelations(alertIds, alertAgents, new Map())
+
+    expect(correlations).toHaveLength(0)
+  })
+})

--- a/__tests__/terminal/ui/command-parser.test.ts
+++ b/__tests__/terminal/ui/command-parser.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect } from 'vitest'
+import {
+  parseCommand,
+  normalizeTeam,
+  validateMatchup,
+  getHelpText,
+} from '@/lib/terminal/ui'
+
+describe('normalizeTeam', () => {
+  it('normalizes team nicknames to abbreviations', () => {
+    expect(normalizeTeam('49ers')).toBe('SF')
+    expect(normalizeTeam('niners')).toBe('SF')
+    expect(normalizeTeam('seahawks')).toBe('SEA')
+    expect(normalizeTeam('chiefs')).toBe('KC')
+  })
+
+  it('handles already abbreviated teams', () => {
+    expect(normalizeTeam('SF')).toBe('SF')
+    expect(normalizeTeam('sea')).toBe('SEA')
+    expect(normalizeTeam('kc')).toBe('KC')
+  })
+
+  it('handles case insensitivity', () => {
+    expect(normalizeTeam('SEAHAWKS')).toBe('SEA')
+    expect(normalizeTeam('Seahawks')).toBe('SEA')
+    expect(normalizeTeam('seahawks')).toBe('SEA')
+  })
+
+  it('trims whitespace', () => {
+    expect(normalizeTeam('  SF  ')).toBe('SF')
+    expect(normalizeTeam(' seahawks ')).toBe('SEA')
+  })
+})
+
+describe('parseCommand', () => {
+  describe('matchup commands', () => {
+    it('parses @ format matchups', () => {
+      const result = parseCommand('SF @ SEA')
+      expect(result.type).toBe('matchup')
+      expect(result.args).toEqual(['SF', 'SEA'])
+    })
+
+    it('parses @ format with team names', () => {
+      const result = parseCommand('49ers @ Seahawks')
+      expect(result.type).toBe('matchup')
+      expect(result.args).toEqual(['SF', 'SEA'])
+    })
+
+    it('parses @ format without spaces', () => {
+      const result = parseCommand('SF@SEA')
+      expect(result.type).toBe('matchup')
+      expect(result.args).toEqual(['SF', 'SEA'])
+    })
+
+    it('parses vs format matchups', () => {
+      const result = parseCommand('Chiefs vs Raiders')
+      expect(result.type).toBe('matchup')
+      expect(result.args).toEqual(['KC', 'LV'])
+    })
+
+    it('parses vs. format with period', () => {
+      const result = parseCommand('GB vs. DET')
+      expect(result.type).toBe('matchup')
+      expect(result.args).toEqual(['GB', 'DET'])
+    })
+  })
+
+  describe('build command', () => {
+    it('parses basic build command', () => {
+      const result = parseCommand('build')
+      expect(result.type).toBe('build')
+      expect(result.args).toEqual([])
+      expect(result.flags).toEqual({})
+    })
+
+    it('parses build with --raw flag', () => {
+      const result = parseCommand('build --raw')
+      expect(result.type).toBe('build')
+      expect(result.flags.raw).toBe(true)
+    })
+
+    it('parses build with --max flag and value', () => {
+      const result = parseCommand('build --max 3')
+      expect(result.type).toBe('build')
+      expect(result.flags.max).toBe('3')
+    })
+
+    it('parses build with multiple flags', () => {
+      const result = parseCommand('build --raw --max 4')
+      expect(result.type).toBe('build')
+      expect(result.flags.raw).toBe(true)
+      expect(result.flags.max).toBe('4')
+    })
+  })
+
+  describe('bet command', () => {
+    it('parses basic bet command', () => {
+      const result = parseCommand('bet')
+      expect(result.type).toBe('bet')
+      expect(result.args).toEqual([])
+    })
+
+    it('parses bet with prop argument', () => {
+      const result = parseCommand('bet chase receptions')
+      expect(result.type).toBe('bet')
+      expect(result.args).toEqual(['chase', 'receptions'])
+    })
+
+    it('parses bet with flags', () => {
+      const result = parseCommand('bet --aggressive')
+      expect(result.type).toBe('bet')
+      expect(result.flags.aggressive).toBe(true)
+    })
+  })
+
+  describe('help command', () => {
+    it('parses help command', () => {
+      const result = parseCommand('help')
+      expect(result.type).toBe('help')
+    })
+
+    it('parses ? as help', () => {
+      const result = parseCommand('?')
+      expect(result.type).toBe('help')
+    })
+  })
+
+  describe('theme command', () => {
+    it('parses theme command without argument', () => {
+      const result = parseCommand('theme')
+      expect(result.type).toBe('theme')
+      expect(result.args).toEqual([])
+    })
+
+    it('parses theme command with team', () => {
+      const result = parseCommand('theme SF')
+      expect(result.type).toBe('theme')
+      expect(result.args).toEqual(['SF'])
+    })
+
+    it('parses theme command with team name', () => {
+      const result = parseCommand('theme Seahawks')
+      expect(result.type).toBe('theme')
+      expect(result.args).toEqual(['Seahawks'])
+    })
+  })
+
+  describe('retry and clear commands', () => {
+    it('parses retry command', () => {
+      const result = parseCommand('retry')
+      expect(result.type).toBe('retry')
+    })
+
+    it('parses clear command', () => {
+      const result = parseCommand('clear')
+      expect(result.type).toBe('clear')
+    })
+
+    it('parses cls as clear', () => {
+      const result = parseCommand('cls')
+      expect(result.type).toBe('clear')
+    })
+  })
+
+  describe('unknown commands', () => {
+    it('returns unknown for empty input', () => {
+      const result = parseCommand('')
+      expect(result.type).toBe('unknown')
+    })
+
+    it('returns unknown for unrecognized input', () => {
+      const result = parseCommand('foobar')
+      expect(result.type).toBe('unknown')
+      expect(result.args).toEqual(['foobar'])
+    })
+
+    it('preserves raw input', () => {
+      const result = parseCommand('some random text')
+      expect(result.type).toBe('unknown')
+      expect(result.raw).toBe('some random text')
+    })
+  })
+})
+
+describe('validateMatchup', () => {
+  it('validates valid matchups', () => {
+    const result = validateMatchup('SF', 'SEA')
+    expect(result.valid).toBe(true)
+    expect(result.error).toBeUndefined()
+  })
+
+  it('rejects unknown away team', () => {
+    const result = validateMatchup('XXX', 'SEA')
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('Unknown team')
+  })
+
+  it('rejects unknown home team', () => {
+    const result = validateMatchup('SF', 'YYY')
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('Unknown team')
+  })
+
+  it('rejects same team matchup', () => {
+    const result = validateMatchup('SF', 'SF')
+    expect(result.valid).toBe(false)
+    expect(result.error).toContain('same')
+  })
+})
+
+describe('getHelpText', () => {
+  it('returns help text with all commands', () => {
+    const help = getHelpText()
+
+    expect(help).toContain('matchup')
+    expect(help).toContain('build')
+    expect(help).toContain('bet')
+    expect(help).toContain('help')
+    expect(help).toContain('theme')
+    expect(help).toContain('retry')
+    expect(help).toContain('clear')
+  })
+
+  it('includes example matchup formats', () => {
+    const help = getHelpText()
+
+    expect(help).toContain('SF @ SEA')
+    expect(help).toContain('49ers @ Seahawks')
+  })
+})

--- a/__tests__/terminal/ui/themes.test.ts
+++ b/__tests__/terminal/ui/themes.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest'
+import {
+  TEAM_THEMES,
+  DEFAULT_THEME,
+  getTeamTheme,
+  getThemeVars,
+} from '@/lib/terminal/ui'
+
+describe('TEAM_THEMES', () => {
+  it('has all 32 NFL teams', () => {
+    const expectedTeams = [
+      // NFC West
+      'SF', 'SEA', 'ARI', 'LAR',
+      // NFC North
+      'CHI', 'DET', 'GB', 'MIN',
+      // NFC East
+      'DAL', 'PHI', 'NYG', 'WAS',
+      // NFC South
+      'ATL', 'CAR', 'NO', 'TB',
+      // AFC West
+      'KC', 'LV', 'DEN', 'LAC',
+      // AFC North
+      'BAL', 'CIN', 'CLE', 'PIT',
+      // AFC South
+      'HOU', 'IND', 'JAX', 'TEN',
+      // AFC East
+      'BUF', 'MIA', 'NE', 'NYJ',
+    ]
+
+    expect(Object.keys(TEAM_THEMES)).toHaveLength(32)
+
+    for (const team of expectedTeams) {
+      expect(TEAM_THEMES[team]).toBeDefined()
+      expect(TEAM_THEMES[team].abbreviation).toBe(team)
+    }
+  })
+
+  it('each team has required color properties', () => {
+    for (const [abbr, theme] of Object.entries(TEAM_THEMES)) {
+      expect(theme.name).toBeDefined()
+      expect(theme.abbreviation).toBe(abbr)
+      expect(theme.primary).toMatch(/^#[0-9A-Fa-f]{6}$/)
+      expect(theme.accent).toMatch(/^#[0-9A-Fa-f]{6}$/)
+      expect(theme.secondary).toMatch(/^#[0-9A-Fa-f]{6}$/)
+    }
+  })
+
+  it('has correct colors for 49ers', () => {
+    const sf = TEAM_THEMES.SF
+    expect(sf.name).toBe('49ers')
+    expect(sf.primary).toBe('#AA0000')
+    expect(sf.accent).toBe('#B3995D')
+  })
+
+  it('has correct colors for Seahawks', () => {
+    const sea = TEAM_THEMES.SEA
+    expect(sea.name).toBe('Seahawks')
+    expect(sea.primary).toBe('#002244')
+    expect(sea.accent).toBe('#69BE28')
+  })
+})
+
+describe('DEFAULT_THEME', () => {
+  it('has Swantail branding', () => {
+    expect(DEFAULT_THEME.name).toBe('Swantail')
+    expect(DEFAULT_THEME.abbreviation).toBe('SWT')
+  })
+
+  it('has dark terminal colors', () => {
+    expect(DEFAULT_THEME.primary).toBe('#0A0A0A')
+    expect(DEFAULT_THEME.accent).toBe('#00FF88')
+  })
+})
+
+describe('getTeamTheme', () => {
+  it('returns team theme for valid abbreviation', () => {
+    const theme = getTeamTheme('SF')
+    expect(theme.name).toBe('49ers')
+    expect(theme.abbreviation).toBe('SF')
+  })
+
+  it('handles lowercase abbreviations', () => {
+    const theme = getTeamTheme('sea')
+    expect(theme.name).toBe('Seahawks')
+  })
+
+  it('returns default theme for unknown team', () => {
+    const theme = getTeamTheme('XXX')
+    expect(theme).toEqual(DEFAULT_THEME)
+  })
+
+  it('returns default theme for empty string', () => {
+    const theme = getTeamTheme('')
+    expect(theme).toEqual(DEFAULT_THEME)
+  })
+})
+
+describe('getThemeVars', () => {
+  it('returns CSS variable object', () => {
+    const vars = getThemeVars(TEAM_THEMES.SF)
+
+    expect(vars['--terminal-bg']).toBe(TEAM_THEMES.SF.secondary)
+    expect(vars['--terminal-primary']).toBe(TEAM_THEMES.SF.primary)
+    expect(vars['--terminal-accent']).toBe(TEAM_THEMES.SF.accent)
+  })
+
+  it('includes all required CSS variables', () => {
+    const vars = getThemeVars(DEFAULT_THEME)
+
+    expect(vars).toHaveProperty('--terminal-bg')
+    expect(vars).toHaveProperty('--terminal-primary')
+    expect(vars).toHaveProperty('--terminal-accent')
+    expect(vars).toHaveProperty('--terminal-text')
+    expect(vars).toHaveProperty('--terminal-muted')
+    expect(vars).toHaveProperty('--terminal-success')
+    expect(vars).toHaveProperty('--terminal-warning')
+    expect(vars).toHaveProperty('--terminal-error')
+  })
+
+  it('returns valid hex colors', () => {
+    const vars = getThemeVars(TEAM_THEMES.KC)
+
+    for (const value of Object.values(vars)) {
+      expect(value).toMatch(/^#[0-9A-Fa-f]{6}$/)
+    }
+  })
+})

--- a/__tests__/terminal/validators.test.ts
+++ b/__tests__/terminal/validators.test.ts
@@ -1,0 +1,413 @@
+import { describe, it, expect } from 'vitest'
+import {
+  validateSourceIntegrity,
+  validateLineFreshness,
+  validateNoEdgeWithoutLine,
+  validateImplications,
+  validateIdAgentMatch,
+  validateConfidenceImmutability,
+  validateAlert,
+  validateAlerts,
+  ValidationError,
+  LINE_TTL,
+} from '@/lib/terminal/engine/validators'
+import type { Alert, Finding } from '@/lib/terminal/schemas'
+
+const NOW = Date.now()
+const ONE_HOUR = 60 * 60 * 1000
+const ONE_DAY = 24 * ONE_HOUR
+
+// =============================================================================
+// FIXTURES
+// =============================================================================
+
+function createValidAlert(overrides?: Partial<Alert>): Alert {
+  return {
+    id: 'test-001',
+    agent: 'epa',
+    evidence: [{
+      stat: 'receiving_epa',
+      value_num: 0.31,
+      value_type: 'numeric',
+      comparison: 'top 5',
+      source_type: 'local',
+      source_ref: 'local://data/epa/week-20.json',
+    }],
+    sources: [{
+      type: 'local',
+      ref: 'local://data/epa/week-20.json',
+      data_version: '2025-week-20',
+      data_timestamp: NOW - 2 * ONE_DAY,
+    }],
+    confidence: 0.75,
+    freshness: 'weekly',
+    severity: 'high',
+    claim: 'Receiving EPA ranks top 5 in league',
+    implications: ['wr_receptions_over', 'wr_yards_over'],
+    suppressions: [],
+    ...overrides,
+  }
+}
+
+function createValidFinding(overrides?: Partial<Finding>): Finding {
+  return {
+    id: 'test-001',
+    agent: 'epa',
+    type: 'receiving_epa_mismatch',
+    stat: 'receiving_epa',
+    value_num: 0.31,
+    value_type: 'numeric',
+    threshold_met: 'rank <= 10',
+    comparison_context: 'top 5',
+    source_ref: 'local://data/epa/week-20.json',
+    source_type: 'local',
+    source_timestamp: NOW - 2 * ONE_DAY,
+    ...overrides,
+  }
+}
+
+// =============================================================================
+// SOURCE INTEGRITY TESTS
+// =============================================================================
+
+describe('validateSourceIntegrity', () => {
+  it('PASS: all evidence refs have matching sources', () => {
+    const alert = createValidAlert()
+    expect(() => validateSourceIntegrity(alert)).not.toThrow()
+  })
+
+  it('FAIL: orphan source (source without evidence)', () => {
+    const alert = createValidAlert({
+      sources: [
+        {
+          type: 'local',
+          ref: 'local://data/epa/week-20.json',
+          data_version: '2025-week-20',
+          data_timestamp: NOW - 2 * ONE_DAY,
+        },
+        {
+          type: 'web',
+          ref: 'https://orphan.com/data',
+          data_version: '2025-week-20',
+          data_timestamp: NOW,
+          search_timestamp: NOW,
+          quote_snippet: 'orphan data',
+        },
+      ],
+    })
+
+    expect(() => validateSourceIntegrity(alert)).toThrow(ValidationError)
+    expect(() => validateSourceIntegrity(alert)).toThrow(/orphan/i)
+  })
+
+  it('FAIL: evidence without source', () => {
+    const alert = createValidAlert({
+      evidence: [
+        {
+          stat: 'receiving_epa',
+          value_num: 0.31,
+          value_type: 'numeric',
+          comparison: 'top 5',
+          source_type: 'local',
+          source_ref: 'local://data/epa/week-20.json',
+        },
+        {
+          stat: 'target_share',
+          value_num: 28,
+          value_type: 'numeric',
+          comparison: 'high',
+          source_type: 'local',
+          source_ref: 'local://data/wr/week-20.json', // No matching source
+        },
+      ],
+    })
+
+    expect(() => validateSourceIntegrity(alert)).toThrow(ValidationError)
+    expect(() => validateSourceIntegrity(alert)).toThrow(/missing source/i)
+  })
+})
+
+// =============================================================================
+// LINE FRESHNESS TESTS
+// =============================================================================
+
+describe('validateLineFreshness', () => {
+  it('PASS: no line evidence', () => {
+    const alert = createValidAlert()
+    expect(() => validateLineFreshness(alert)).not.toThrow()
+  })
+
+  it('PASS: fresh spread line (< 30 min)', () => {
+    const alert = createValidAlert({
+      evidence: [{
+        stat: 'spread',
+        value_num: -3.5,
+        value_type: 'numeric',
+        comparison: 'current',
+        source_type: 'line',
+        source_ref: 'https://book.com',
+        line_type: 'spread',
+        line_value: -3.5,
+        line_odds: -110,
+        book: 'DK',
+        line_timestamp: NOW - 10 * 60 * 1000, // 10 min ago
+        line_ttl: LINE_TTL.spread,
+      }],
+      sources: [{
+        type: 'line',
+        ref: 'https://book.com',
+        data_version: '2025-week-20',
+        data_timestamp: NOW - 10 * 60 * 1000,
+      }],
+    })
+
+    expect(() => validateLineFreshness(alert)).not.toThrow()
+  })
+
+  it('FAIL: stale spread line (> 30 min)', () => {
+    const alert = createValidAlert({
+      evidence: [{
+        stat: 'spread',
+        value_num: -3.5,
+        value_type: 'numeric',
+        comparison: 'current',
+        source_type: 'line',
+        source_ref: 'https://book.com',
+        line_type: 'spread',
+        line_value: -3.5,
+        line_odds: -110,
+        book: 'DK',
+        line_timestamp: NOW - 60 * 60 * 1000, // 60 min ago
+        line_ttl: LINE_TTL.spread,
+      }],
+      sources: [{
+        type: 'line',
+        ref: 'https://book.com',
+        data_version: '2025-week-20',
+        data_timestamp: NOW - 60 * 60 * 1000,
+      }],
+    })
+
+    expect(() => validateLineFreshness(alert)).toThrow(ValidationError)
+    expect(() => validateLineFreshness(alert)).toThrow(/stale.*spread/i)
+  })
+
+  it('FAIL: stale prop line (> 15 min)', () => {
+    const alert = createValidAlert({
+      evidence: [{
+        stat: 'player_yards',
+        value_num: 75.5,
+        value_type: 'numeric',
+        comparison: 'current',
+        source_type: 'line',
+        source_ref: 'https://book.com',
+        line_type: 'prop',
+        line_value: 75.5,
+        line_odds: -110,
+        book: 'DK',
+        line_timestamp: NOW - 20 * 60 * 1000, // 20 min ago
+        line_ttl: LINE_TTL.prop,
+      }],
+      sources: [{
+        type: 'line',
+        ref: 'https://book.com',
+        data_version: '2025-week-20',
+        data_timestamp: NOW - 20 * 60 * 1000,
+      }],
+    })
+
+    expect(() => validateLineFreshness(alert)).toThrow(ValidationError)
+    expect(() => validateLineFreshness(alert)).toThrow(/stale.*prop/i)
+  })
+})
+
+// =============================================================================
+// EDGE LANGUAGE TESTS
+// =============================================================================
+
+describe('validateNoEdgeWithoutLine', () => {
+  it('PASS: normal claim without edge language', () => {
+    const alert = createValidAlert({
+      claim: 'Receiving EPA ranks top 5 in league vs opponent average',
+    })
+    expect(() => validateNoEdgeWithoutLine(alert)).not.toThrow()
+  })
+
+  it('PASS: edge language WITH line evidence', () => {
+    const alert = createValidAlert({
+      claim: 'This spread offers clear value',
+      evidence: [{
+        stat: 'spread',
+        value_num: -3.5,
+        value_type: 'numeric',
+        comparison: 'current',
+        source_type: 'line',
+        source_ref: 'https://book.com',
+        line_type: 'spread',
+        line_value: -3.5,
+        line_odds: -110,
+        book: 'DK',
+        line_timestamp: NOW - 5 * 60 * 1000,
+        line_ttl: LINE_TTL.spread,
+      }],
+      sources: [{
+        type: 'line',
+        ref: 'https://book.com',
+        data_version: '2025-week-20',
+        data_timestamp: NOW - 5 * 60 * 1000,
+      }],
+    })
+    expect(() => validateNoEdgeWithoutLine(alert)).not.toThrow()
+  })
+
+  const edgeClaims = [
+    'This is a clear edge against the market',
+    'Great value on this line',
+    'The spread is mispriced here',
+    'Time to exploit this matchup',
+    'Sharp money favors the over',
+    'This is a lock for the week',
+  ]
+
+  for (const claim of edgeClaims) {
+    it(`FAIL: "${claim.slice(0, 30)}..." without LineEvidence`, () => {
+      const alert = createValidAlert({ claim })
+      expect(() => validateNoEdgeWithoutLine(alert)).toThrow(ValidationError)
+      expect(() => validateNoEdgeWithoutLine(alert)).toThrow(/edge language/i)
+    })
+  }
+})
+
+// =============================================================================
+// IMPLICATIONS TESTS
+// =============================================================================
+
+describe('validateImplications', () => {
+  it('PASS: EPA agent with valid implications', () => {
+    const alert = createValidAlert({
+      agent: 'epa',
+      implications: ['wr_receptions_over', 'wr_yards_over'],
+    })
+    expect(() => validateImplications(alert)).not.toThrow()
+  })
+
+  it('FAIL: EPA agent with pressure implication', () => {
+    const alert = createValidAlert({
+      agent: 'epa',
+      implications: ['qb_sacks_over'], // Not in EPA allowlist
+    })
+    expect(() => validateImplications(alert)).toThrow(ValidationError)
+    expect(() => validateImplications(alert)).toThrow(/cannot imply.*qb_sacks_over/i)
+  })
+
+  it('FAIL: Weather agent with QB implication', () => {
+    const alert = createValidAlert({
+      agent: 'weather',
+      implications: ['qb_pass_tds_over'], // Not in weather allowlist
+    })
+    expect(() => validateImplications(alert)).toThrow(ValidationError)
+  })
+
+  it('PASS: Pressure agent with valid implications', () => {
+    const alert = createValidAlert({
+      agent: 'pressure',
+      implications: ['qb_sacks_over', 'qb_ints_over'],
+    })
+    expect(() => validateImplications(alert)).not.toThrow()
+  })
+})
+
+// =============================================================================
+// ID/AGENT MATCH TESTS
+// =============================================================================
+
+describe('validateIdAgentMatch', () => {
+  it('PASS: ID and agent match', () => {
+    const alert = createValidAlert()
+    const finding = createValidFinding()
+    expect(() => validateIdAgentMatch(alert, finding)).not.toThrow()
+  })
+
+  it('FAIL: ID mismatch', () => {
+    const alert = createValidAlert({ id: 'different-id' })
+    const finding = createValidFinding({ id: 'test-001' })
+    expect(() => validateIdAgentMatch(alert, finding)).toThrow(ValidationError)
+    expect(() => validateIdAgentMatch(alert, finding)).toThrow(/id mismatch/i)
+  })
+
+  it('FAIL: Agent mismatch', () => {
+    const alert = createValidAlert({ agent: 'pressure' })
+    const finding = createValidFinding({ agent: 'epa' })
+    expect(() => validateIdAgentMatch(alert, finding)).toThrow(ValidationError)
+    expect(() => validateIdAgentMatch(alert, finding)).toThrow(/agent mismatch/i)
+  })
+})
+
+// =============================================================================
+// CONFIDENCE IMMUTABILITY TESTS
+// =============================================================================
+
+describe('validateConfidenceImmutability', () => {
+  it('PASS: confidence matches expected', () => {
+    const alert = createValidAlert({ confidence: 0.75 })
+    expect(() => validateConfidenceImmutability(alert, 0.75)).not.toThrow()
+  })
+
+  it('PASS: allows tiny floating point difference', () => {
+    const alert = createValidAlert({ confidence: 0.750001 })
+    expect(() => validateConfidenceImmutability(alert, 0.75)).not.toThrow()
+  })
+
+  it('FAIL: confidence was modified', () => {
+    const alert = createValidAlert({ confidence: 0.9 })
+    expect(() => validateConfidenceImmutability(alert, 0.75)).toThrow(ValidationError)
+    expect(() => validateConfidenceImmutability(alert, 0.75)).toThrow(/modified/i)
+  })
+})
+
+// =============================================================================
+// FULL VALIDATION CHAIN TESTS
+// =============================================================================
+
+describe('validateAlert (full chain)', () => {
+  it('PASS: fully valid alert', () => {
+    const alert = createValidAlert()
+    const finding = createValidFinding()
+    expect(() => validateAlert(alert, finding, 0.75)).not.toThrow()
+  })
+
+  it('FAIL: cascades first error found', () => {
+    const alert = createValidAlert({
+      id: 'wrong-id',
+      confidence: 0.99,
+    })
+    const finding = createValidFinding()
+
+    expect(() => validateAlert(alert, finding, 0.75)).toThrow(ValidationError)
+  })
+})
+
+describe('validateAlerts (batch)', () => {
+  it('returns valid alerts and collects errors', () => {
+    const goodAlert = createValidAlert({ id: 'good-001' })
+    const badAlert = createValidAlert({
+      id: 'bad-001',
+      implications: ['qb_sacks_over'], // Invalid for EPA agent
+    })
+
+    const goodFinding = createValidFinding({ id: 'good-001' })
+    const badFinding = createValidFinding({ id: 'bad-001' })
+
+    const result = validateAlerts(
+      [goodAlert, badAlert],
+      [goodFinding, badFinding],
+      new Map([['good-001', 0.75], ['bad-001', 0.75]])
+    )
+
+    expect(result.valid).toHaveLength(1)
+    expect(result.valid[0].id).toBe('good-001')
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0].alertId).toBe('bad-001')
+    expect(result.errors[0].error.code).toBe('INVALID_IMPLICATIONS')
+  })
+})

--- a/app/api/terminal/bet/route.ts
+++ b/app/api/terminal/bet/route.ts
@@ -1,0 +1,282 @@
+import { NextRequest } from 'next/server'
+import { z } from 'zod'
+import {
+  LadderSchema,
+  BetResultSchema,
+  organizeLadders,
+  type Ladder,
+  type RiskTier,
+  type Rung,
+} from '@/lib/terminal/schemas'
+import { hashObject, generateRequestId } from '@/lib/terminal/engine/provenance'
+import { checkRequestLimits, estimateTokens } from '@/lib/terminal/engine/guardrails'
+
+/**
+ * /api/terminal/bet
+ *
+ * Organize alerts into risk-tiered betting ladders.
+ * Groups bets by confidence/risk level for bankroll management.
+ *
+ * Input: Alert IDs + metadata
+ * Output: Ladder[] (tiered prop bet recommendations)
+ */
+
+const BetRequestSchema = z.object({
+  alert_ids: z.array(z.string()).min(1).describe('Alert IDs to organize into ladders'),
+  // Alert metadata needed for ladder organization
+  alert_metadata: z.array(z.object({
+    id: z.string(),
+    agent: z.enum(['epa', 'pressure', 'weather', 'qb', 'hb', 'wr', 'te']),
+    market: z.string(),
+    line: z.number().optional(),
+    confidence: z.number().min(0).max(1),
+    severity: z.enum(['high', 'medium']),
+    claim: z.string().optional(), // Human-readable claim for rationale
+  })),
+  options: z.object({
+    include_aggressive: z.boolean().default(true),
+    max_rungs_per_ladder: z.number().min(1).max(5).default(3),
+  }).optional(),
+})
+
+type BetRequest = z.infer<typeof BetRequestSchema>
+
+/**
+ * Calculate recommended stake percentage based on tier
+ */
+function calculateStakePct(tier: RiskTier, confidence: number): number {
+  const baseStakes: Record<RiskTier, number> = {
+    safe: 5,
+    moderate: 3,
+    aggressive: 1,
+  }
+
+  // Adjust by average confidence
+  const adjustment = (confidence - 0.5) * 2 // -1 to +1 range
+  const stake = baseStakes[tier] + adjustment
+
+  // Clamp between 0.5% and 10%
+  return Math.round(Math.max(0.5, Math.min(10, stake)) * 10) / 10
+}
+
+/**
+ * Calculate total implied probability for rungs
+ */
+function calculateTotalImpliedProbability(rungs: Rung[]): number {
+  const probabilities = rungs.map(r => r.implied_probability || 0.5)
+  // Average probability for single bets (not parlay)
+  const avg = probabilities.reduce((acc, p) => acc + p, 0) / probabilities.length
+  return Math.round(avg * 100) / 100
+}
+
+/**
+ * Build a rung from alert metadata
+ */
+function buildRung(meta: BetRequest['alert_metadata'][0]): Rung {
+  return {
+    alert_id: meta.id,
+    market: meta.market,
+    line: meta.line,
+    implied_probability: meta.confidence,
+    agent: meta.agent,
+    rationale: meta.claim || `${meta.agent.toUpperCase()} agent signal - ${meta.severity} severity`,
+  }
+}
+
+/**
+ * Build a ladder from tier organization
+ */
+function buildLadder(
+  organization: { tier: RiskTier; ids: string[]; name: string },
+  alertMetadataMap: Map<string, BetRequest['alert_metadata'][0]>,
+  index: number,
+  maxRungs: number
+): Ladder | null {
+  const rungs = organization.ids
+    .slice(0, maxRungs)
+    .map(id => {
+      const meta = alertMetadataMap.get(id)
+      if (!meta) return null
+      return buildRung(meta)
+    })
+    .filter(Boolean) as Rung[]
+
+  if (rungs.length === 0) return null
+
+  const totalProb = calculateTotalImpliedProbability(rungs)
+  const avgConfidence = rungs.reduce((acc, r) => acc + (r.implied_probability || 0.5), 0) / rungs.length
+
+  const ladder: Ladder = {
+    id: `ladder-${organization.tier}-${index}-${Date.now()}`,
+    name: organization.name,
+    tier: organization.tier,
+    rungs,
+    total_implied_probability: totalProb,
+    recommended_stake_pct: calculateStakePct(organization.tier, avgConfidence),
+    provenance_hash: hashObject({ tier: organization.tier, ids: organization.ids }),
+  }
+
+  return ladder
+}
+
+export async function POST(req: NextRequest) {
+  const requestId = generateRequestId()
+  const startTime = Date.now()
+
+  try {
+    // Parse request body
+    const body = await req.json()
+    const parsed = BetRequestSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return Response.json(
+        {
+          error: 'Invalid request',
+          details: parsed.error.flatten(),
+          request_id: requestId,
+        },
+        { status: 400 }
+      )
+    }
+
+    const { alert_ids, alert_metadata, options } = parsed.data
+    const includeAggressive = options?.include_aggressive ?? true
+    const maxRungs = options?.max_rungs_per_ladder ?? 3
+
+    // Check guardrails
+    const inputEstimate = estimateTokens(JSON.stringify(alert_metadata))
+    checkRequestLimits({ inputTokens: inputEstimate })
+
+    // Build metadata maps
+    const alertConfidences = new Map(alert_metadata.map(m => [m.id, m.confidence]))
+    const alertSeverities = new Map(alert_metadata.map(m => [m.id, m.severity]))
+    const alertMetadataMap = new Map(alert_metadata.map(m => [m.id, m]))
+
+    // Organize into tiers
+    const organizations = organizeLadders(alert_ids, alertConfidences, alertSeverities)
+
+    if (organizations.length === 0) {
+      return Response.json({
+        request_id: requestId,
+        ladders: [],
+        alerts_used: [],
+        alerts_excluded: alert_ids,
+        message: 'No alerts qualify for betting ladders. Confidence levels may be too low.',
+        bet_timestamp: Date.now(),
+        provenance_hash: hashObject({ alert_ids, timestamp: Date.now() }),
+        timing_ms: Date.now() - startTime,
+      })
+    }
+
+    // Filter out aggressive if not included
+    const filteredOrgs = includeAggressive
+      ? organizations
+      : organizations.filter(o => o.tier !== 'aggressive')
+
+    // Build ladders
+    const ladders: Ladder[] = []
+    const alertsUsed = new Set<string>()
+
+    for (let i = 0; i < filteredOrgs.length; i++) {
+      const org = filteredOrgs[i]
+      const ladder = buildLadder(org, alertMetadataMap, i, maxRungs)
+
+      if (ladder) {
+        // Validate against schema
+        const validated = LadderSchema.safeParse(ladder)
+        if (validated.success) {
+          ladders.push(validated.data)
+          org.ids.slice(0, maxRungs).forEach(id => alertsUsed.add(id))
+        }
+      }
+    }
+
+    // Determine excluded alerts
+    const alertsExcluded = alert_ids.filter(id => !alertsUsed.has(id))
+
+    // Build result
+    const result = {
+      request_id: requestId,
+      ladders,
+      alerts_used: Array.from(alertsUsed),
+      alerts_excluded: alertsExcluded,
+      bet_timestamp: Date.now(),
+      provenance_hash: hashObject({ ladders, alert_ids, timestamp: Date.now() }),
+    }
+
+    // Validate result against schema
+    const validatedResult = BetResultSchema.safeParse(result)
+    if (!validatedResult.success) {
+      return Response.json(
+        {
+          error: 'Bet result validation failed',
+          details: validatedResult.error.flatten(),
+          request_id: requestId,
+        },
+        { status: 500 }
+      )
+    }
+
+    return Response.json({
+      ...validatedResult.data,
+      timing_ms: Date.now() - startTime,
+    })
+  } catch (error) {
+    return Response.json(
+      {
+        error: 'Bet organization failed',
+        message: (error as Error).message,
+        request_id: requestId,
+      },
+      { status: 500 }
+    )
+  }
+}
+
+// GET for health check / discovery
+export async function GET() {
+  return Response.json({
+    endpoint: '/api/terminal/bet',
+    method: 'POST',
+    description: 'Organize alerts into risk-tiered betting ladders',
+    schema: {
+      alert_ids: 'string[] - Alert IDs to organize (min 1)',
+      alert_metadata: '[{ id, agent, market, line?, confidence, severity, claim? }]',
+      options: {
+        include_aggressive: 'boolean (default: true)',
+        max_rungs_per_ladder: 'number (1-5, default: 3)',
+      },
+    },
+    risk_tiers: {
+      safe: 'High confidence (>=0.7) + high severity - Lower risk, consistent value',
+      moderate: 'Medium confidence (0.5-0.7) or medium severity - Balanced approach',
+      aggressive: 'Lower confidence (0.3-0.5) - Higher risk, higher potential',
+    },
+    stake_recommendations: {
+      safe: '~5% of bankroll',
+      moderate: '~3% of bankroll',
+      aggressive: '~1% of bankroll',
+    },
+    example: {
+      alert_ids: ['epa-123', 'pressure-456'],
+      alert_metadata: [
+        {
+          id: 'epa-123',
+          agent: 'epa',
+          market: 'Chase Over 85.5 Yards',
+          line: 85.5,
+          confidence: 0.75,
+          severity: 'high',
+          claim: 'Elite efficiency vs weak coverage',
+        },
+        {
+          id: 'pressure-456',
+          agent: 'pressure',
+          market: 'Bosa 1+ Sacks',
+          confidence: 0.55,
+          severity: 'medium',
+        },
+      ],
+    },
+  })
+}

--- a/app/api/terminal/build/route.ts
+++ b/app/api/terminal/build/route.ts
@@ -1,0 +1,271 @@
+import { NextRequest } from 'next/server'
+import { z } from 'zod'
+import {
+  ScriptSchema,
+  BuildResultSchema,
+  identifyCorrelations,
+  type Script,
+  type CorrelationType,
+} from '@/lib/terminal/schemas'
+import { hashObject, generateRequestId } from '@/lib/terminal/engine/provenance'
+import { checkRequestLimits, estimateTokens } from '@/lib/terminal/engine/guardrails'
+
+/**
+ * /api/terminal/build
+ *
+ * Build correlated parlay scripts from alerts.
+ * Identifies correlation patterns and groups alerts into parlays.
+ *
+ * Input: Alert IDs + metadata
+ * Output: Script[] (correlated parlay recommendations)
+ */
+
+const BuildRequestSchema = z.object({
+  alert_ids: z.array(z.string()).min(2).describe('Alert IDs to build parlays from'),
+  // Alert metadata needed for correlation analysis
+  alert_metadata: z.array(z.object({
+    id: z.string(),
+    agent: z.enum(['epa', 'pressure', 'weather', 'qb', 'hb', 'wr', 'te']),
+    market: z.string(),
+    confidence: z.number().min(0).max(1),
+    implications: z.array(z.string()).optional(),
+  })),
+  options: z.object({
+    max_legs: z.number().min(2).max(6).default(4),
+    risk_preference: z.enum(['conservative', 'moderate', 'aggressive']).default('moderate'),
+  }).optional(),
+})
+
+type BuildRequest = z.infer<typeof BuildRequestSchema>
+
+/**
+ * Calculate combined confidence for a parlay script
+ */
+function calculateCombinedConfidence(
+  legConfidences: number[],
+  correlationBonus: number = 0
+): number {
+  // Base: product of individual confidences (independent events)
+  const baseConfidence = legConfidences.reduce((acc, c) => acc * c, 1)
+
+  // Correlation bonus adjusts for positive correlation (events more likely together)
+  // Capped to prevent overconfidence
+  const adjusted = Math.min(baseConfidence + correlationBonus * 0.1, 0.95)
+
+  return Math.round(adjusted * 100) / 100
+}
+
+/**
+ * Determine risk level based on confidence and leg count
+ */
+function determineRiskLevel(
+  confidence: number,
+  legCount: number
+): 'conservative' | 'moderate' | 'aggressive' {
+  if (legCount <= 2 && confidence >= 0.5) {
+    return 'conservative'
+  }
+  if (legCount <= 4 && confidence >= 0.3) {
+    return 'moderate'
+  }
+  return 'aggressive'
+}
+
+/**
+ * Build a script from a correlation match
+ */
+function buildScript(
+  correlation: { type: CorrelationType; ids: string[]; explanation: string },
+  alertMetadata: Map<string, BuildRequest['alert_metadata'][0]>,
+  index: number
+): Script | null {
+  const legs = correlation.ids.map(id => {
+    const meta = alertMetadata.get(id)
+    if (!meta) return null
+    return {
+      alert_id: id,
+      market: meta.market,
+      implied_probability: meta.confidence,
+      agent: meta.agent,
+    }
+  }).filter(Boolean)
+
+  if (legs.length < 2) return null
+
+  const confidences = legs.map(l => l!.implied_probability || 0.5)
+  const combinedConfidence = calculateCombinedConfidence(confidences, 0.15)
+  const riskLevel = determineRiskLevel(combinedConfidence, legs.length)
+
+  const script: Script = {
+    id: `script-${correlation.type}-${index}-${Date.now()}`,
+    name: formatScriptName(correlation.type),
+    legs: legs as Script['legs'],
+    correlation_type: correlation.type,
+    correlation_explanation: correlation.explanation,
+    combined_confidence: combinedConfidence,
+    risk_level: riskLevel,
+    provenance_hash: hashObject({ type: correlation.type, ids: correlation.ids }),
+  }
+
+  return script
+}
+
+/**
+ * Format human-readable script name from correlation type
+ */
+function formatScriptName(type: CorrelationType): string {
+  const names: Record<CorrelationType, string> = {
+    game_script: 'Game Script Stack',
+    player_stack: 'Player Stack Parlay',
+    weather_cascade: 'Weather Impact Parlay',
+    defensive_funnel: 'Defensive Pressure Stack',
+    volume_share: 'Target Volume Parlay',
+  }
+  return names[type] || 'Custom Parlay'
+}
+
+export async function POST(req: NextRequest) {
+  const requestId = generateRequestId()
+  const startTime = Date.now()
+
+  try {
+    // Parse request body
+    const body = await req.json()
+    const parsed = BuildRequestSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return Response.json(
+        {
+          error: 'Invalid request',
+          details: parsed.error.flatten(),
+          request_id: requestId,
+        },
+        { status: 400 }
+      )
+    }
+
+    const { alert_ids, alert_metadata, options } = parsed.data
+    const maxLegs = options?.max_legs || 4
+
+    // Check guardrails
+    const inputEstimate = estimateTokens(JSON.stringify(alert_metadata))
+    checkRequestLimits({ inputTokens: inputEstimate })
+
+    // Build metadata maps for correlation analysis
+    const alertAgents = new Map(alert_metadata.map(m => [m.id, m.agent]))
+    const alertImplications = new Map(alert_metadata.map(m => [m.id, m.implications || []]))
+    const alertMetadataMap = new Map(alert_metadata.map(m => [m.id, m]))
+
+    // Identify correlation patterns
+    const correlations = identifyCorrelations(alert_ids, alertAgents, alertImplications)
+
+    if (correlations.length === 0) {
+      return Response.json({
+        request_id: requestId,
+        scripts: [],
+        alerts_used: [],
+        alerts_excluded: alert_ids,
+        message: 'No correlation patterns identified. Alerts may not have compatible relationships.',
+        build_timestamp: Date.now(),
+        provenance_hash: hashObject({ alert_ids, timestamp: Date.now() }),
+        timing_ms: Date.now() - startTime,
+      })
+    }
+
+    // Build scripts from correlations
+    const scripts: Script[] = []
+    const alertsUsed = new Set<string>()
+
+    for (let i = 0; i < correlations.length; i++) {
+      const correlation = correlations[i]
+
+      // Limit legs per script
+      const limitedCorrelation = {
+        ...correlation,
+        ids: correlation.ids.slice(0, maxLegs),
+      }
+
+      const script = buildScript(limitedCorrelation, alertMetadataMap, i)
+      if (script) {
+        // Validate against schema
+        const validated = ScriptSchema.safeParse(script)
+        if (validated.success) {
+          scripts.push(validated.data)
+          limitedCorrelation.ids.forEach(id => alertsUsed.add(id))
+        }
+      }
+    }
+
+    // Determine excluded alerts
+    const alertsExcluded = alert_ids.filter(id => !alertsUsed.has(id))
+
+    // Build result
+    const result = {
+      request_id: requestId,
+      scripts,
+      alerts_used: Array.from(alertsUsed),
+      alerts_excluded: alertsExcluded,
+      build_timestamp: Date.now(),
+      provenance_hash: hashObject({ scripts, alert_ids, timestamp: Date.now() }),
+    }
+
+    // Validate result against schema
+    const validatedResult = BuildResultSchema.safeParse(result)
+    if (!validatedResult.success) {
+      return Response.json(
+        {
+          error: 'Build result validation failed',
+          details: validatedResult.error.flatten(),
+          request_id: requestId,
+        },
+        { status: 500 }
+      )
+    }
+
+    return Response.json({
+      ...validatedResult.data,
+      timing_ms: Date.now() - startTime,
+    })
+  } catch (error) {
+    return Response.json(
+      {
+        error: 'Build failed',
+        message: (error as Error).message,
+        request_id: requestId,
+      },
+      { status: 500 }
+    )
+  }
+}
+
+// GET for health check / discovery
+export async function GET() {
+  return Response.json({
+    endpoint: '/api/terminal/build',
+    method: 'POST',
+    description: 'Build correlated parlay scripts from alerts',
+    schema: {
+      alert_ids: 'string[] - Alert IDs to build parlays from (min 2)',
+      alert_metadata: '[{ id, agent, market, confidence, implications? }]',
+      options: {
+        max_legs: 'number (2-6, default: 4)',
+        risk_preference: 'conservative | moderate | aggressive',
+      },
+    },
+    correlation_types: [
+      'game_script - EPA + rushing patterns',
+      'player_stack - QB + receiver combos',
+      'weather_cascade - weather affects passing',
+      'defensive_funnel - pressure + QB metrics',
+      'volume_share - target concentration',
+    ],
+    example: {
+      alert_ids: ['epa-123', 'pressure-456', 'qb-789'],
+      alert_metadata: [
+        { id: 'epa-123', agent: 'epa', market: 'Chase Over 85.5', confidence: 0.72 },
+        { id: 'pressure-456', agent: 'pressure', market: 'Burrow Under 275.5', confidence: 0.68 },
+        { id: 'qb-789', agent: 'qb', market: 'Burrow Under 2.5 TDs', confidence: 0.65 },
+      ],
+    },
+  })
+}

--- a/app/api/terminal/scan/route.ts
+++ b/app/api/terminal/scan/route.ts
@@ -1,0 +1,307 @@
+import { NextRequest } from 'next/server'
+import { z } from 'zod'
+import { runAgents, type MatchupContext } from '@/lib/terminal/engine/agent-runner'
+import { buildProvenance, generateRequestId } from '@/lib/terminal/engine/provenance'
+import {
+  renderFindingsFallback,
+  formatFallbackForApi,
+  shouldUseFallback,
+} from '@/lib/terminal/engine/fallback-renderer'
+import { checkRequestLimits, estimateTokens } from '@/lib/terminal/engine/guardrails'
+
+/**
+ * /api/terminal/scan
+ *
+ * Scan a matchup for betting opportunities.
+ * Returns Finding[] from all agents.
+ *
+ * Future: Will integrate LLM analyst to transform Finding[] → Alert[]
+ */
+
+const ScanRequestSchema = z.object({
+  matchup: z.string().min(3).describe('e.g., "49ers @ Seahawks" or "SF @ SEA"'),
+  options: z
+    .object({
+      includeWeather: z.boolean().default(true),
+      includeProps: z.boolean().default(true),
+    })
+    .optional(),
+})
+
+type ScanRequest = z.infer<typeof ScanRequestSchema>
+
+// Team name mappings
+const TEAM_ALIASES: Record<string, string> = {
+  '49ers': 'SF',
+  niners: 'SF',
+  'san francisco': 'SF',
+  seahawks: 'SEA',
+  seattle: 'SEA',
+  cardinals: 'ARI',
+  arizona: 'ARI',
+  rams: 'LAR',
+  'los angeles rams': 'LAR',
+  chiefs: 'KC',
+  'kansas city': 'KC',
+  raiders: 'LV',
+  'las vegas': 'LV',
+  broncos: 'DEN',
+  denver: 'DEN',
+  chargers: 'LAC',
+  'los angeles chargers': 'LAC',
+  cowboys: 'DAL',
+  dallas: 'DAL',
+  eagles: 'PHI',
+  philadelphia: 'PHI',
+  giants: 'NYG',
+  'new york giants': 'NYG',
+  commanders: 'WAS',
+  washington: 'WAS',
+  bears: 'CHI',
+  chicago: 'CHI',
+  lions: 'DET',
+  detroit: 'DET',
+  packers: 'GB',
+  'green bay': 'GB',
+  vikings: 'MIN',
+  minnesota: 'MIN',
+  falcons: 'ATL',
+  atlanta: 'ATL',
+  panthers: 'CAR',
+  carolina: 'CAR',
+  saints: 'NO',
+  'new orleans': 'NO',
+  buccaneers: 'TB',
+  bucs: 'TB',
+  'tampa bay': 'TB',
+  ravens: 'BAL',
+  baltimore: 'BAL',
+  bengals: 'CIN',
+  cincinnati: 'CIN',
+  browns: 'CLE',
+  cleveland: 'CLE',
+  steelers: 'PIT',
+  pittsburgh: 'PIT',
+  texans: 'HOU',
+  houston: 'HOU',
+  colts: 'IND',
+  indianapolis: 'IND',
+  jaguars: 'JAX',
+  jacksonville: 'JAX',
+  titans: 'TEN',
+  tennessee: 'TEN',
+  bills: 'BUF',
+  buffalo: 'BUF',
+  dolphins: 'MIA',
+  miami: 'MIA',
+  patriots: 'NE',
+  'new england': 'NE',
+  jets: 'NYJ',
+  'new york jets': 'NYJ',
+}
+
+function normalizeTeamName(name: string): string {
+  const lower = name.toLowerCase().trim()
+  return TEAM_ALIASES[lower] || name.toUpperCase()
+}
+
+function parseMatchup(matchup: string): { homeTeam: string; awayTeam: string } | null {
+  // Try "@" format: "SF @ SEA" or "49ers @ Seahawks"
+  const atMatch = matchup.match(/^(.+?)\s*@\s*(.+)$/i)
+  if (atMatch) {
+    return {
+      awayTeam: normalizeTeamName(atMatch[1]),
+      homeTeam: normalizeTeamName(atMatch[2]),
+    }
+  }
+
+  // Try "vs" format: "SF vs SEA"
+  const vsMatch = matchup.match(/^(.+?)\s*vs\.?\s*(.+)$/i)
+  if (vsMatch) {
+    return {
+      homeTeam: normalizeTeamName(vsMatch[1]),
+      awayTeam: normalizeTeamName(vsMatch[2]),
+    }
+  }
+
+  return null
+}
+
+/**
+ * Load matchup context from data layer
+ * TODO: Implement actual data loading from local files + web search
+ */
+async function loadMatchupContext(
+  homeTeam: string,
+  awayTeam: string
+): Promise<MatchupContext> {
+  // For now, return mock data structure
+  // This will be replaced with actual data loading
+  return {
+    homeTeam,
+    awayTeam,
+    players: {
+      [homeTeam]: [],
+      [awayTeam]: [],
+    },
+    teamStats: {
+      [homeTeam]: {},
+      [awayTeam]: {},
+    },
+    weather: {
+      temperature: 55,
+      wind_mph: 8,
+      precipitation_chance: 10,
+      indoor: false,
+    },
+    dataTimestamp: Date.now(),
+    dataVersion: `2025-week-${Math.ceil((Date.now() - new Date('2025-09-01').getTime()) / (7 * 24 * 60 * 60 * 1000))}`,
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const requestId = generateRequestId()
+  const startTime = Date.now()
+
+  try {
+    // Parse request body
+    const body = await req.json()
+    const parsed = ScanRequestSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return Response.json(
+        {
+          error: 'Invalid request',
+          details: parsed.error.flatten(),
+          request_id: requestId,
+        },
+        { status: 400 }
+      )
+    }
+
+    // Parse matchup string
+    const teams = parseMatchup(parsed.data.matchup)
+    if (!teams) {
+      return Response.json(
+        {
+          error: 'Invalid matchup format',
+          message: 'Use format: "Team1 @ Team2" or "Team1 vs Team2"',
+          examples: ['SF @ SEA', '49ers @ Seahawks', 'Chiefs vs Raiders'],
+          request_id: requestId,
+        },
+        { status: 400 }
+      )
+    }
+
+    // Load matchup context
+    const matchupContext = await loadMatchupContext(teams.homeTeam, teams.awayTeam)
+
+    // Check guardrails
+    const inputEstimate = estimateTokens(JSON.stringify(matchupContext))
+    checkRequestLimits({ inputTokens: inputEstimate })
+
+    // Run threshold checks (deterministic)
+    const { findings, agentsInvoked, agentsSilent } = await runAgents(matchupContext)
+
+    // Build provenance
+    const provenance = buildProvenance({
+      requestId,
+      prompt: '', // No LLM call in this phase
+      skillMds: {},
+      findings,
+      dataVersion: matchupContext.dataVersion,
+      dataTimestamp: matchupContext.dataTimestamp,
+      searchTimestamps: [],
+      agentsInvoked,
+      agentsSilent,
+      cacheHits: 0,
+      cacheMisses: 0,
+      llmModel: 'none',
+      llmTemperature: 0,
+    })
+
+    // If no findings, return early
+    if (findings.length === 0) {
+      return Response.json({
+        request_id: requestId,
+        matchup: {
+          home: teams.homeTeam,
+          away: teams.awayTeam,
+        },
+        findings: [],
+        alerts: [],
+        message: 'No significant findings for this matchup. All agents silent.',
+        agents: {
+          invoked: agentsInvoked,
+          silent: agentsSilent,
+        },
+        provenance,
+        timing_ms: Date.now() - startTime,
+      })
+    }
+
+    // For now, return findings with fallback format
+    // TODO: Task 12 will add LLM analyst to transform Finding[] → Alert[]
+    const fallbackOutput = formatFallbackForApi(findings)
+
+    return Response.json({
+      request_id: requestId,
+      matchup: {
+        home: teams.homeTeam,
+        away: teams.awayTeam,
+      },
+      findings,
+      fallback: fallbackOutput,
+      agents: {
+        invoked: agentsInvoked,
+        silent: agentsSilent,
+      },
+      provenance,
+      timing_ms: Date.now() - startTime,
+      _note:
+        'Alert[] output pending LLM analyst integration. Using fallback renderer.',
+    })
+  } catch (error) {
+    // Check if we should use fallback mode
+    if (shouldUseFallback(error)) {
+      return Response.json(
+        {
+          error: 'Scan degraded',
+          message: 'Using fallback mode due to service issue',
+          fallback: true,
+          request_id: requestId,
+        },
+        { status: 503 }
+      )
+    }
+
+    return Response.json(
+      {
+        error: 'Scan failed',
+        message: (error as Error).message,
+        request_id: requestId,
+      },
+      { status: 500 }
+    )
+  }
+}
+
+// GET for health check / discovery
+export async function GET() {
+  return Response.json({
+    endpoint: '/api/terminal/scan',
+    method: 'POST',
+    description: 'Scan a matchup for betting opportunities',
+    schema: {
+      matchup: 'string - e.g., "SF @ SEA" or "49ers @ Seahawks"',
+      options: {
+        includeWeather: 'boolean (default: true)',
+        includeProps: 'boolean (default: true)',
+      },
+    },
+    examples: [
+      { matchup: 'SF @ SEA' },
+      { matchup: 'Chiefs @ Raiders', options: { includeWeather: true } },
+    ],
+  })
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,6 +4,16 @@
 
 :root {
   color-scheme: dark;
+
+  /* Terminal theme colors (dynamically updated via JS) */
+  --terminal-bg: #0A0A0A;
+  --terminal-primary: #1A1A1A;
+  --terminal-accent: #00FF88;
+  --terminal-text: #E0E0E0;
+  --terminal-muted: #808080;
+  --terminal-success: #00FF88;
+  --terminal-warning: #FFB612;
+  --terminal-error: #FF4444;
 }
 
 html, body, #__next {

--- a/app/terminal/page.tsx
+++ b/app/terminal/page.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { Terminal } from '@/components/terminal'
+import { useCallback } from 'react'
+
+export default function TerminalPage() {
+  // Handler for matchup scanning
+  const handleMatchup = useCallback(async (away: string, home: string) => {
+    try {
+      const response = await fetch('/api/terminal/scan', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ matchup: `${away} @ ${home}` }),
+      })
+
+      const data = await response.json()
+
+      // TODO: Display findings/alerts in terminal
+      console.log('Scan result:', data)
+    } catch (error) {
+      console.error('Scan failed:', error)
+      throw error
+    }
+  }, [])
+
+  // Handler for building parlays
+  const handleBuild = useCallback(async (args: string[], flags: Record<string, string | boolean>) => {
+    try {
+      // TODO: Get alerts from previous scan and call /api/terminal/build
+      console.log('Build requested with args:', args, 'flags:', flags)
+    } catch (error) {
+      console.error('Build failed:', error)
+      throw error
+    }
+  }, [])
+
+  // Handler for betting ladders
+  const handleBet = useCallback(async (args: string[], flags: Record<string, string | boolean>) => {
+    try {
+      // TODO: Get alerts from previous scan and call /api/terminal/bet
+      console.log('Bet requested with args:', args, 'flags:', flags)
+    } catch (error) {
+      console.error('Bet failed:', error)
+      throw error
+    }
+  }, [])
+
+  return (
+    <main className="h-screen w-screen overflow-hidden bg-terminal-bg">
+      <Terminal
+        onMatchup={handleMatchup}
+        onBuild={handleBuild}
+        onBet={handleBet}
+      />
+    </main>
+  )
+}

--- a/components/terminal/Terminal.tsx
+++ b/components/terminal/Terminal.tsx
@@ -1,0 +1,294 @@
+'use client'
+
+import React, { useState, useRef, useEffect, useCallback } from 'react'
+import { parseCommand, getHelpText, validateMatchup, getTeamTheme, applyTheme, DEFAULT_THEME } from '@/lib/terminal/ui'
+import type { ParsedCommand, TeamTheme } from '@/lib/terminal/ui'
+
+interface TerminalLine {
+  id: string
+  type: 'input' | 'output' | 'error' | 'system' | 'agent'
+  content: string
+  timestamp: number
+}
+
+interface TerminalProps {
+  onMatchup?: (away: string, home: string) => Promise<void>
+  onBuild?: (args: string[], flags: Record<string, string | boolean>) => Promise<void>
+  onBet?: (args: string[], flags: Record<string, string | boolean>) => Promise<void>
+}
+
+export function Terminal({ onMatchup, onBuild, onBet }: TerminalProps) {
+  const [lines, setLines] = useState<TerminalLine[]>([])
+  const [input, setInput] = useState('')
+  const [history, setHistory] = useState<string[]>([])
+  const [historyIndex, setHistoryIndex] = useState(-1)
+  const [theme, setTheme] = useState<TeamTheme>(DEFAULT_THEME)
+  const [isProcessing, setIsProcessing] = useState(false)
+  const [lastCommand, setLastCommand] = useState<string | null>(null)
+
+  const inputRef = useRef<HTMLInputElement>(null)
+  const outputRef = useRef<HTMLDivElement>(null)
+
+  // Auto-scroll to bottom
+  useEffect(() => {
+    if (outputRef.current) {
+      outputRef.current.scrollTop = outputRef.current.scrollHeight
+    }
+  }, [lines])
+
+  // Focus input on mount
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  // Apply theme
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      applyTheme(theme)
+    }
+  }, [theme])
+
+  // Initialize terminal
+  useEffect(() => {
+    addLine('system', '~/swantail terminal                                    Opus 4.5')
+    addLine('system', '─────────────────────────────────────────────────────────────────')
+    addLine('system', 'initializing agents...')
+    addLine('agent', '├─ weather    ready')
+    addLine('agent', '├─ pressure   ready')
+    addLine('agent', '├─ epa        ready')
+    addLine('agent', '├─ qb         ready')
+    addLine('agent', '├─ hb         ready')
+    addLine('agent', '├─ wr         ready')
+    addLine('agent', '└─ te         ready')
+    addLine('system', '')
+    addLine('system', 'Type a matchup (e.g., "SF @ SEA") or "help" for commands.')
+  }, [])
+
+  const addLine = useCallback((type: TerminalLine['type'], content: string) => {
+    setLines(prev => [...prev, {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+      type,
+      content,
+      timestamp: Date.now(),
+    }])
+  }, [])
+
+  const handleCommand = useCallback(async (cmd: ParsedCommand) => {
+    setIsProcessing(true)
+
+    try {
+      switch (cmd.type) {
+        case 'matchup': {
+          const [away, home] = cmd.args
+          const validation = validateMatchup(away, home)
+
+          if (!validation.valid) {
+            addLine('error', `Error: ${validation.error}`)
+            break
+          }
+
+          // Apply team theme
+          const homeTheme = getTeamTheme(home)
+          setTheme(homeTheme)
+
+          addLine('system', '')
+          addLine('system', `∴ ${away} @ ${home}`)
+          addLine('system', '')
+          addLine('system', '🔍 Scanning agents...')
+
+          if (onMatchup) {
+            await onMatchup(away, home)
+          } else {
+            addLine('output', '(Demo mode - connect onMatchup handler for live scanning)')
+          }
+          break
+        }
+
+        case 'build': {
+          addLine('system', '')
+          addLine('system', '🔧 Building parlay scripts...')
+
+          if (onBuild) {
+            await onBuild(cmd.args, cmd.flags)
+          } else {
+            addLine('output', '(Demo mode - connect onBuild handler for parlay generation)')
+          }
+          break
+        }
+
+        case 'bet': {
+          addLine('system', '')
+          addLine('system', '📊 Organizing betting ladders...')
+
+          if (onBet) {
+            await onBet(cmd.args, cmd.flags)
+          } else {
+            addLine('output', '(Demo mode - connect onBet handler for ladder generation)')
+          }
+          break
+        }
+
+        case 'help': {
+          addLine('output', getHelpText())
+          break
+        }
+
+        case 'theme': {
+          if (cmd.args.length === 0) {
+            addLine('output', `Current theme: ${theme.name} (${theme.abbreviation})`)
+            addLine('output', 'Usage: theme [team] - e.g., "theme SF" or "theme Seahawks"')
+          } else {
+            const newTheme = getTeamTheme(cmd.args[0])
+            if (newTheme !== DEFAULT_THEME || cmd.args[0].toUpperCase() === 'SWT') {
+              setTheme(newTheme)
+              addLine('output', `Theme changed to ${newTheme.name}`)
+            } else {
+              addLine('error', `Unknown team: ${cmd.args[0]}`)
+            }
+          }
+          break
+        }
+
+        case 'retry': {
+          if (lastCommand) {
+            addLine('system', `Retrying: ${lastCommand}`)
+            const retryCmd = parseCommand(lastCommand)
+            await handleCommand(retryCmd)
+          } else {
+            addLine('error', 'No previous command to retry')
+          }
+          break
+        }
+
+        case 'clear': {
+          setLines([])
+          break
+        }
+
+        case 'unknown': {
+          addLine('error', `Unknown command: ${cmd.raw}`)
+          addLine('output', 'Type "help" for available commands.')
+          break
+        }
+      }
+    } catch (error) {
+      addLine('error', `Error: ${(error as Error).message}`)
+    } finally {
+      setIsProcessing(false)
+    }
+  }, [addLine, lastCommand, onMatchup, onBuild, onBet, theme])
+
+  const handleSubmit = useCallback((e: React.FormEvent) => {
+    e.preventDefault()
+    if (!input.trim() || isProcessing) return
+
+    // Add input to history
+    setHistory(prev => [...prev, input])
+    setHistoryIndex(-1)
+
+    // Display input
+    addLine('input', `∴ ${input}`)
+
+    // Parse and execute
+    const cmd = parseCommand(input)
+
+    // Save for retry (except retry itself)
+    if (cmd.type !== 'retry') {
+      setLastCommand(input)
+    }
+
+    handleCommand(cmd)
+
+    // Clear input
+    setInput('')
+  }, [input, isProcessing, addLine, handleCommand])
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      if (history.length > 0) {
+        const newIndex = historyIndex === -1
+          ? history.length - 1
+          : Math.max(0, historyIndex - 1)
+        setHistoryIndex(newIndex)
+        setInput(history[newIndex])
+      }
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      if (historyIndex !== -1) {
+        const newIndex = historyIndex + 1
+        if (newIndex >= history.length) {
+          setHistoryIndex(-1)
+          setInput('')
+        } else {
+          setHistoryIndex(newIndex)
+          setInput(history[newIndex])
+        }
+      }
+    }
+  }, [history, historyIndex])
+
+  const getLineClassName = (type: TerminalLine['type']): string => {
+    const base = 'font-mono whitespace-pre-wrap'
+    switch (type) {
+      case 'input':
+        return `${base} text-terminal-accent`
+      case 'output':
+        return `${base} text-terminal-text`
+      case 'error':
+        return `${base} text-terminal-error`
+      case 'system':
+        return `${base} text-terminal-muted`
+      case 'agent':
+        return `${base} text-terminal-success`
+      default:
+        return base
+    }
+  }
+
+  return (
+    <div
+      className="flex flex-col h-full bg-terminal-bg text-terminal-text font-mono"
+      onClick={() => inputRef.current?.focus()}
+    >
+      {/* Output area */}
+      <div
+        ref={outputRef}
+        className="flex-1 overflow-y-auto p-4 space-y-1"
+      >
+        {lines.map(line => (
+          <div key={line.id} className={getLineClassName(line.type)}>
+            {line.content}
+          </div>
+        ))}
+
+        {isProcessing && (
+          <div className="text-terminal-warning animate-pulse">
+            Processing...
+          </div>
+        )}
+      </div>
+
+      {/* Input area */}
+      <form onSubmit={handleSubmit} className="border-t border-terminal-muted/20 p-4">
+        <div className="flex items-center gap-2">
+          <span className="text-terminal-accent">∴</span>
+          <input
+            ref={inputRef}
+            type="text"
+            value={input}
+            onChange={e => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            disabled={isProcessing}
+            className="flex-1 bg-transparent outline-none text-terminal-text placeholder-terminal-muted"
+            placeholder={isProcessing ? 'Processing...' : 'Enter command...'}
+            autoComplete="off"
+            spellCheck={false}
+          />
+        </div>
+      </form>
+    </div>
+  )
+}
+
+export default Terminal

--- a/components/terminal/index.ts
+++ b/components/terminal/index.ts
@@ -1,0 +1,1 @@
+export { Terminal } from './Terminal'

--- a/docs/plans/2026-01-16-swantail-terminal-design.md
+++ b/docs/plans/2026-01-16-swantail-terminal-design.md
@@ -1,0 +1,510 @@
+# Swantail Terminal Design
+
+> **Status:** Approved
+> **Date:** 2026-01-16
+> **Replaces:** Current Next.js form-based builder + Render wrapper
+
+---
+
+## Product Overview
+
+**Swantail Terminal** - A web-based CLI interface for sports betting analysis powered by specialized AI agents.
+
+**Core loop:**
+1. User selects or types a matchup
+2. Agents scan their domains against matchup data
+3. Only agents with statistically significant + betting-relevant findings surface alerts
+4. User runs `build` for correlated longshot parlays or `bet [prop]` for ladder analysis
+
+**Key differentiators:**
+- Alert-driven (agents stay silent unless something's interesting)
+- Skill MDs define each agent's expertise and voice
+- Typed code defines thresholds (testable, not prompt-debugged)
+- Single analyst LLM synthesizes all findings (cost-efficient, cross-referenced)
+- Team color theming per matchup
+- Hybrid data: automated feeds + manual overrides + web search fallback
+
+**Not a form. Not a chatbot. A terminal with specialists hunting edges.**
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     VERCEL (Next.js)                            │
+│                                                                 │
+│  FRONTEND                                                       │
+│  └─ Terminal emulator (React)                                   │
+│     └─ Team color theming                                       │
+│     └─ Command parser                                           │
+│     └─ Streaming output display                                 │
+│     └─ Heartbeat events                                         │
+│                                                                 │
+│  API ROUTES                                                     │
+│  ├─ POST /api/scan      → agents scan, return alerts (stream)   │
+│  ├─ POST /api/build     → generate parlays from alerts (stream) │
+│  ├─ POST /api/bet       → prop ladder analysis (stream)         │
+│  ├─ GET  /api/matchups  → list games                            │
+│  └─ GET  /api/theme     → team colors                           │
+│                                                                 │
+│  AGENT ENGINE (lib/)                                            │
+│  ├─ skills/agents/*.md  → agent voice & metric definitions      │
+│  ├─ agents/*/thresholds.ts → typed threshold logic (testable)   │
+│  ├─ engine/filter.ts    → threshold checks → Finding[]          │
+│  ├─ engine/confidence.ts → code-derived confidence              │
+│  ├─ engine/search.ts    → web search fallback                   │
+│  ├─ engine/analyst.ts   → LLM call (Finding[] → Alert[])        │
+│  └─ engine/validate.ts  → validator chain                       │
+│                                                                 │
+│  DATA (JSON files, refreshed weekly)                            │
+│  └─ data/{epa,pressure,projections,lines,weather}/*.json        │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+
+External:
+- OpenAI API (direct calls with streaming, JSON mode)
+- Web search API (Tavily/Perplexity for fallback)
+- Weather API (automated refresh)
+```
+
+**What gets deleted:**
+- `my-parlaygpt/` folder (entire wrapper service)
+- Render deployment
+- All WRAPPER_* env vars
+- Inter-service auth logic
+
+---
+
+## Agents
+
+| Agent | Domain | Key Metrics |
+|-------|--------|-------------|
+| EPA | Expected Points Added | receiving_epa, rushing_epa, red_zone_epa |
+| Pressure | Pass rush & protection | pressure_rate, pass_block_win_rate, sack_rate |
+| Weather | Environmental factors | temperature, wind, precipitation |
+| QB | Quarterback analysis | completion_rate, yards_per_attempt, passer_rating |
+| HB | Halfback/RB analysis | rush_yards, yards_after_contact, target_share |
+| WR | Wide receiver analysis | target_share, separation, contested_catch_rate |
+| TE | Tight end analysis | route_participation, red_zone_targets |
+
+---
+
+## Data Pipeline
+
+```
+┌─────────────┐  ┌─────────────┐  ┌─────────────┐
+│  AUTOMATED  │  │   MANUAL    │  │  WEB SEARCH │
+│             │  │             │  │  (fallback) │
+│ -FantasyPros│  │ -Your angles│  │             │
+│ -Weather API│  │ -Injury intel│ │ -Triggered  │
+│ -Lines feeds│  │ -Prop values│  │  when stale │
+│ -EPA sources│  │ -Overrides  │  │  or missing │
+└──────┬──────┘  └──────┬──────┘  └──────┬──────┘
+       │                │                │
+       └────────────────┼────────────────┘
+                        ▼
+            ┌───────────────────────┐
+            │   MATCHUP CONTEXT DB  │
+            │   (weekly refresh)    │
+            └───────────────────────┘
+```
+
+### Web Search Guardrails
+
+```typescript
+const SEARCH_CONFIG = {
+  enabled: true,                    // kill-switch
+  budgetPerMatchup: 5,              // max searches per scan
+  budgetPerAgent: 2,                // max per agent per scan
+  cacheTTL: 3600 * 4,               // 4 hours
+  noiseThreshold: 0.3,              // if confidence < 0.3, don't use
+}
+```
+
+---
+
+## Contract Layer
+
+### Finding (Pre-LLM, Deterministic)
+
+```typescript
+interface Finding {
+  id: string                        // "epa-jsn-recv-001"
+  agent: AgentType
+  type: string                      // "receiving_epa_mismatch"
+  stat: string
+  value_num?: number
+  value_str?: string
+  value_type: "numeric" | "string"
+  threshold_met: string             // "rank <= 10"
+  comparison_context: string        // "3rd in league"
+  source_ref: string                // normalized path or URL
+  source_type: "local" | "web"
+  source_timestamp: number
+  quote_snippet?: string            // if web
+}
+```
+
+### LLM Output (Keyed by Finding ID)
+
+```typescript
+// LLM outputs keyed map - cannot relabel id/agent
+const LLMOutputSchema = z.record(
+  z.string(),  // finding_id
+  z.object({
+    severity: z.enum(["high", "medium"]),
+    claim_parts: ClaimPartsSchema,
+    implications: z.array(z.string()),
+    suppressions: z.array(z.string()),
+  }).strict()
+)
+```
+
+### ClaimParts (Structured, No Free Text)
+
+```typescript
+const ClaimPartsSchema = z.object({
+  metrics: z.array(z.enum([
+    "receiving_epa", "rushing_epa", "pass_block_win_rate",
+    "pressure_rate", "target_share", "snap_count",
+    "red_zone_epa", "epa_allowed", "completion_rate",
+    "yards_per_attempt", "sack_rate",
+  ])).min(1),
+  direction: z.enum(["positive", "negative", "neutral"]),
+  comparator: z.enum(["ranks", "exceeds", "trails", "matches", "diverges_from"]),
+  rank_or_percentile: z.object({
+    type: z.enum(["rank", "percentile"]),
+    value: z.number(),
+    scope: z.enum(["league", "position", "conference", "division"]),
+    direction: z.enum(["top", "bottom"]),
+  }).optional(),
+  comparison_target: z.enum([
+    "league_average", "opponent_average", "position_average",
+    "season_baseline", "historical_self"
+  ]).optional(),
+  context_qualifier: z.enum([
+    "in_division", "at_home", "as_underdog", "in_primetime",
+    "vs_top_10_defense", "with_current_qb"
+  ]).optional(),
+}).strict()
+```
+
+### Alert (Final Output)
+
+```typescript
+interface Alert {
+  // FROM CODE (immutable)
+  id: string
+  agent: AgentType
+  evidence: (Evidence | LineEvidence)[]
+  sources: Source[]
+  confidence: number                // code-derived
+  freshness: "live" | "weekly" | "stale"
+
+  // FROM LLM (constrained)
+  severity: "high" | "medium"
+  claim: string                     // rendered from claim_parts
+  implications: string[]            // validated against allowlist
+  suppressions: string[]
+}
+```
+
+### Evidence Types
+
+```typescript
+interface Evidence {
+  stat: string
+  value_num?: number
+  value_str?: string
+  value_type: "numeric" | "string"
+  comparison: string
+  source_type: "local" | "web"
+  source_ref: string
+  quote_snippet?: string
+}
+
+interface LineEvidence extends Evidence {
+  line_type: "spread" | "total" | "prop" | "moneyline"
+  line_value: number
+  line_odds: number
+  book: string
+  line_timestamp: number
+  line_ttl: number
+}
+```
+
+### Line Freshness TTL
+
+```typescript
+const LINE_TTL = {
+  spread: 30 * 60 * 1000,      // 30 min
+  total: 30 * 60 * 1000,       // 30 min
+  prop: 15 * 60 * 1000,        // 15 min (more volatile)
+  moneyline: 60 * 60 * 1000,   // 1 hr
+}
+```
+
+---
+
+## Confidence Calculation (Code-Derived)
+
+```typescript
+function calculateConfidence(inputs: ConfidenceInputs): number {
+  let score = 0.5  // baseline
+
+  // Evidence quantity
+  if (inputs.evidenceCount >= 3) score += 0.15
+  else if (inputs.evidenceCount >= 2) score += 0.08
+
+  // Source quality
+  if (inputs.hasLocalSource) score += 0.10
+  if (inputs.hasWebSource && inputs.webSourceAge < 4 * 3600 * 1000) {
+    score += 0.08
+  }
+
+  // Sample size
+  if (inputs.sampleSize !== null) {
+    if (inputs.sampleSize >= 100) score += 0.12
+    else if (inputs.sampleSize >= 50) score += 0.06
+    else score -= 0.10
+  }
+
+  // Line freshness
+  if (inputs.hasLineEvidence) {
+    if (inputs.lineAge < 30 * 60 * 1000) score += 0.10
+    else if (inputs.lineAge < 2 * 3600 * 1000) score += 0.05
+    else score -= 0.15
+  }
+
+  // Data freshness
+  if (inputs.localDataAge > 7 * 24 * 3600 * 1000) score -= 0.20
+
+  return Math.max(0, Math.min(1, score))
+}
+```
+
+---
+
+## Implications Allowlist
+
+```typescript
+const AGENT_IMPLICATIONS: Record<AgentType, string[]> = {
+  epa: [
+    "wr_receptions_over", "wr_receptions_under",
+    "wr_yards_over", "wr_yards_under",
+    "rb_yards_over", "rb_yards_under",
+    "team_total_over", "team_total_under",
+  ],
+  pressure: [
+    "qb_sacks_over", "qb_sacks_under",
+    "qb_ints_over", "qb_pass_yards_under",
+    "def_sacks_over",
+  ],
+  weather: [
+    "game_total_under", "pass_yards_under", "field_goals_over",
+  ],
+  qb: [
+    "qb_pass_yards_over", "qb_pass_yards_under",
+    "qb_pass_tds_over", "qb_pass_tds_under",
+    "qb_completions_over", "qb_completions_under",
+    "qb_ints_over",
+  ],
+  hb: [
+    "rb_rush_yards_over", "rb_rush_yards_under",
+    "rb_receptions_over", "rb_rush_attempts_over",
+    "rb_tds_over",
+  ],
+  wr: [
+    "wr_receptions_over", "wr_receptions_under",
+    "wr_yards_over", "wr_yards_under",
+    "wr_tds_over", "wr_longest_reception_over",
+  ],
+  te: [
+    "te_receptions_over", "te_receptions_under",
+    "te_yards_over", "te_yards_under",
+    "te_tds_over",
+  ],
+}
+```
+
+---
+
+## Validator Chain
+
+All validators must pass before Alert is returned:
+
+1. **Zod .strict()** - no extra fields anywhere
+2. **ID/Agent match** - must equal Finding values
+3. **Confidence immutable** - must equal code-derived value
+4. **Source integrity** - no orphan sources, all evidence refs have sources
+5. **LineEvidence freshness** - within TTL per line type
+6. **ClaimParts structured** - must parse against schema
+7. **Implications allowlist** - must be in agent + finding allowlist
+8. **No edge language without line** - blocks "edge", "value", "mispriced" without LineEvidence
+
+---
+
+## Reproducibility
+
+Every response includes provenance:
+
+```typescript
+interface Provenance {
+  request_id: string
+  prompt_hash: string
+  skill_md_hashes: Record<AgentType, string>
+  findings_hash: string
+  data_version: string
+  data_timestamp: number
+  search_timestamps: number[]
+  agents_invoked: AgentType[]
+  agents_silent: AgentType[]
+  cache_hits: number
+  cache_misses: number
+  llm_model: string
+  llm_temperature: number  // should be 0
+}
+```
+
+---
+
+## Operational Guardrails
+
+```typescript
+const REQUEST_LIMITS = {
+  maxInputTokens: 8000,
+  maxOutputTokens: 2000,
+  maxCostPerRequest: 0.15,
+  timeoutMs: 45000,
+}
+
+const STREAM_CONFIG = {
+  heartbeatIntervalMs: 3000,
+  heartbeatPayload: { type: "heartbeat", status: "processing" },
+}
+```
+
+### Fallback Renderer (No LLM)
+
+If analyst LLM fails, terminal displays raw findings:
+
+```
+⚠️  Analyst offline. Raw findings:
+
+   [epa] receiving_epa_rank: 3 (top 5 in league)
+         → local://data/epa/week-20.json
+
+   [pressure] pressure_rate: 42% (top 3 in league)
+              → local://data/pressure/week-20.json
+
+   Type "retry" or "build --raw" to continue.
+```
+
+---
+
+## Terminal UI
+
+### Commands
+
+| Command | Action |
+|---------|--------|
+| `[matchup]` | Select game, trigger agent scan |
+| `build` | Generate correlated parlay scripts from alerts |
+| `bet [prop]` | Generate prop ladder with agent commentary |
+| `help` | Show available commands |
+| `theme [team]` | Switch color theme |
+| `retry` | Re-run last command |
+
+### Example Flow
+
+```
+~/swantail terminal                                    Opus 4.5
+─────────────────────────────────────────────────────────────────
+initializing agents...
+├─ weather    ready
+├─ pressure   ready
+├─ epa        ready
+├─ qb         ready
+├─ hb         ready
+├─ wr         ready
+└─ te         ready
+
+∴ 49ers @ seahawks
+
+🔍 Scanning agents...
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+🚨 EPA Agent
+   Receiving EPA + Target Share ranks top 5 in league vs opponent average
+   → JSN receptions/yards worth investigating
+
+🚨 Pressure Agent
+   Pressure Rate ranks top 3 in league
+   → SF sacks, Darnold INTs correlate
+
+⏸ Weather Agent — nothing notable
+⏸ HB Agent — nothing notable
+⏸ TE Agent — nothing notable
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+2 alerts. type "build" or "bet jsn receptions"
+
+∴ build
+
+┌─────────────────────────────────────────────────────────────────┐
+│  SCRIPT 1: "Seattle Collapses Under Pressure"                  │
+│                                                                 │
+│  ├─ Darnold Under 224.5 pass yds                               │
+│  ├─ JSN Over 6.5 receptions                                    │
+│  └─ SF Over 2.5 sacks                                          │
+│                                                                 │
+│  Correlation: Pressure forces quick throws → JSN volume,       │
+│  but capped yardage. Sacks compound.                           │
+│                                                                 │
+│  $1 → $14.80 (illustrative)                                    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Team Color Theming
+
+Load team colors dynamically per matchup:
+- Primary: #AA0000 (49ers red) or #002244 (Seahawks navy)
+- Accent: #B3995D (49ers gold) or #69BE28 (Seahawks green)
+- User can toggle home/away theme
+
+---
+
+## What LLM Controls vs Code Controls
+
+| LLM Controls | Code Controls |
+|--------------|---------------|
+| severity | id |
+| claim_parts (structured) | agent |
+| implications (allowlist) | evidence |
+| suppressions | sources |
+| | confidence |
+| | freshness |
+| | line validation |
+| | all hashes |
+
+---
+
+## Migration Path
+
+1. **Delete wrapper** - Remove `my-parlaygpt/`, Render deployment, WRAPPER_* env vars
+2. **Build terminal UI** - React terminal emulator with command parser
+3. **Build agent engine** - Threshold code + skill MDs + analyst LLM
+4. **Build validators** - Zod schemas + custom validation chain
+5. **Wire data pipeline** - Local JSON + web search fallback
+6. **Add team theming** - Extend `lib/nfl/teams.ts` with hex colors
+
+---
+
+## Open Questions (For Implementation)
+
+1. Which web search API? (Tavily vs Perplexity vs raw Google)
+2. Terminal library? (xterm.js vs custom React)
+3. Streaming format? (SSE vs WebSocket)
+4. Data refresh automation? (cron vs manual trigger)

--- a/docs/plans/2026-01-16-swantail-terminal-implementation.md
+++ b/docs/plans/2026-01-16-swantail-terminal-implementation.md
@@ -1,0 +1,2326 @@
+# Swantail Terminal Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build an agent-based terminal UI for sports betting analysis with strict contracts, threshold-based alerting, and correlated parlay generation.
+
+**Architecture:** Web-based terminal (React) calls Next.js API routes. Typed threshold code produces Finding[], single LLM call transforms to Alert[], strict validators enforce contracts. No wrapper service.
+
+**Tech Stack:** Next.js 14, React, Zod, OpenAI SDK (streaming), TypeScript, Tailwind CSS
+
+---
+
+## Task 1: Core Zod Schemas
+
+**Files:**
+- Create: `lib/terminal/schemas/evidence.ts`
+- Create: `lib/terminal/schemas/finding.ts`
+- Create: `lib/terminal/schemas/alert.ts`
+- Create: `lib/terminal/schemas/claim.ts`
+- Create: `lib/terminal/schemas/provenance.ts`
+- Create: `lib/terminal/schemas/index.ts`
+- Test: `__tests__/terminal/schemas.test.ts`
+
+**Step 1: Write failing test for Evidence schema**
+
+```typescript
+// __tests__/terminal/schemas.test.ts
+import { describe, it, expect } from 'vitest'
+import { EvidenceSchema, LineEvidenceSchema } from '@/lib/terminal/schemas'
+
+describe('EvidenceSchema', () => {
+  it('accepts valid numeric evidence', () => {
+    const evidence = {
+      stat: 'receiving_epa_rank',
+      value_num: 3,
+      value_type: 'numeric' as const,
+      comparison: 'top 5 in league',
+      source_type: 'local' as const,
+      source_ref: 'local://data/epa/week-20.json',
+    }
+    expect(() => EvidenceSchema.parse(evidence)).not.toThrow()
+  })
+
+  it('rejects extra fields (strict mode)', () => {
+    const evidence = {
+      stat: 'receiving_epa_rank',
+      value_num: 3,
+      value_type: 'numeric' as const,
+      comparison: 'top 5 in league',
+      source_type: 'local' as const,
+      source_ref: 'local://data/epa/week-20.json',
+      extraField: 'should fail',
+    }
+    expect(() => EvidenceSchema.parse(evidence)).toThrow()
+  })
+
+  it('requires quote_snippet for web sources', () => {
+    const evidence = {
+      stat: 'pressure_rate',
+      value_num: 42,
+      value_type: 'numeric' as const,
+      comparison: 'top 3 in league',
+      source_type: 'web' as const,
+      source_ref: 'https://example.com/stats',
+      // missing quote_snippet
+    }
+    expect(() => EvidenceSchema.parse(evidence)).toThrow()
+  })
+})
+
+describe('LineEvidenceSchema', () => {
+  it('accepts valid line evidence', () => {
+    const lineEvidence = {
+      stat: 'spread',
+      value_num: -3.5,
+      value_type: 'numeric' as const,
+      comparison: 'current line',
+      source_type: 'line' as const,
+      source_ref: 'https://sportsbook.com/lines',
+      line_type: 'spread' as const,
+      line_value: -3.5,
+      line_odds: -110,
+      book: 'DraftKings',
+      line_timestamp: Date.now(),
+      line_ttl: 30 * 60 * 1000,
+    }
+    expect(() => LineEvidenceSchema.parse(lineEvidence)).not.toThrow()
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd /Users/zfarleymacstudio/AFBParlay/.worktrees/swantail-terminal && npm test -- --run __tests__/terminal/schemas.test.ts`
+Expected: FAIL (module not found)
+
+**Step 3: Set up vitest and create Evidence schema**
+
+First, install vitest if not present:
+```bash
+npm install -D vitest @vitejs/plugin-react
+```
+
+Create vitest config:
+```typescript
+// vitest.config.ts
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './'),
+    },
+  },
+})
+```
+
+Add to package.json scripts:
+```json
+"test": "vitest"
+```
+
+```typescript
+// lib/terminal/schemas/evidence.ts
+import { z } from 'zod'
+
+export const EvidenceSchema = z.object({
+  stat: z.string(),
+  value_num: z.number().optional(),
+  value_str: z.string().optional(),
+  value_type: z.enum(['numeric', 'string']),
+  comparison: z.string(),
+  source_type: z.enum(['local', 'web']),
+  source_ref: z.string(),
+  quote_snippet: z.string().optional(),
+}).strict().refine(
+  (data) => {
+    // Web sources require quote_snippet
+    if (data.source_type === 'web' && !data.quote_snippet) {
+      return false
+    }
+    return true
+  },
+  { message: 'Web sources require quote_snippet' }
+)
+
+export const LineEvidenceSchema = z.object({
+  stat: z.string(),
+  value_num: z.number().optional(),
+  value_str: z.string().optional(),
+  value_type: z.enum(['numeric', 'string']),
+  comparison: z.string(),
+  source_type: z.literal('line'),
+  source_ref: z.string(),
+  quote_snippet: z.string().optional(),
+  line_type: z.enum(['spread', 'total', 'prop', 'moneyline']),
+  line_value: z.number(),
+  line_odds: z.number(),
+  book: z.string(),
+  line_timestamp: z.number(),
+  line_ttl: z.number(),
+}).strict()
+
+export type Evidence = z.infer<typeof EvidenceSchema>
+export type LineEvidence = z.infer<typeof LineEvidenceSchema>
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm test -- --run __tests__/terminal/schemas.test.ts`
+Expected: PASS
+
+**Step 5: Write failing test for Finding schema**
+
+Add to `__tests__/terminal/schemas.test.ts`:
+```typescript
+import { FindingSchema, AgentType } from '@/lib/terminal/schemas'
+
+describe('FindingSchema', () => {
+  it('accepts valid finding', () => {
+    const finding = {
+      id: 'epa-jsn-recv-001',
+      agent: 'epa' as AgentType,
+      type: 'receiving_epa_mismatch',
+      stat: 'receiving_epa_rank',
+      value_num: 3,
+      value_type: 'numeric' as const,
+      threshold_met: 'rank <= 10',
+      comparison_context: '3rd in league',
+      source_ref: 'local://data/epa/week-20.json',
+      source_type: 'local' as const,
+      source_timestamp: Date.now(),
+    }
+    expect(() => FindingSchema.parse(finding)).not.toThrow()
+  })
+})
+```
+
+**Step 6: Run test to verify it fails**
+
+Run: `npm test -- --run __tests__/terminal/schemas.test.ts`
+Expected: FAIL (FindingSchema not found)
+
+**Step 7: Create Finding schema**
+
+```typescript
+// lib/terminal/schemas/finding.ts
+import { z } from 'zod'
+
+export const AgentTypeSchema = z.enum(['epa', 'pressure', 'weather', 'qb', 'hb', 'wr', 'te'])
+export type AgentType = z.infer<typeof AgentTypeSchema>
+
+export const FindingSchema = z.object({
+  id: z.string(),
+  agent: AgentTypeSchema,
+  type: z.string(),
+  stat: z.string(),
+  value_num: z.number().optional(),
+  value_str: z.string().optional(),
+  value_type: z.enum(['numeric', 'string']),
+  threshold_met: z.string(),
+  comparison_context: z.string(),
+  source_ref: z.string(),
+  source_type: z.enum(['local', 'web']),
+  source_timestamp: z.number(),
+  quote_snippet: z.string().optional(),
+}).strict()
+
+export type Finding = z.infer<typeof FindingSchema>
+```
+
+**Step 8: Run test to verify it passes**
+
+Run: `npm test -- --run __tests__/terminal/schemas.test.ts`
+Expected: PASS
+
+**Step 9: Write failing test for ClaimParts schema**
+
+Add to `__tests__/terminal/schemas.test.ts`:
+```typescript
+import { ClaimPartsSchema } from '@/lib/terminal/schemas'
+
+describe('ClaimPartsSchema', () => {
+  it('accepts valid claim parts', () => {
+    const claimParts = {
+      metrics: ['receiving_epa', 'target_share'],
+      direction: 'positive' as const,
+      comparator: 'ranks' as const,
+      rank_or_percentile: {
+        type: 'rank' as const,
+        value: 5,
+        scope: 'league' as const,
+        direction: 'top' as const,
+      },
+      comparison_target: 'opponent_average' as const,
+    }
+    expect(() => ClaimPartsSchema.parse(claimParts)).not.toThrow()
+  })
+
+  it('rejects invalid metrics', () => {
+    const claimParts = {
+      metrics: ['fake_metric'],
+      direction: 'positive' as const,
+      comparator: 'ranks' as const,
+    }
+    expect(() => ClaimPartsSchema.parse(claimParts)).toThrow()
+  })
+})
+```
+
+**Step 10: Run test to verify it fails**
+
+Run: `npm test -- --run __tests__/terminal/schemas.test.ts`
+Expected: FAIL (ClaimPartsSchema not found)
+
+**Step 11: Create ClaimParts schema**
+
+```typescript
+// lib/terminal/schemas/claim.ts
+import { z } from 'zod'
+
+export const MetricSchema = z.enum([
+  'receiving_epa', 'rushing_epa', 'pass_block_win_rate',
+  'pressure_rate', 'target_share', 'snap_count',
+  'red_zone_epa', 'epa_allowed', 'completion_rate',
+  'yards_per_attempt', 'sack_rate', 'passer_rating',
+  'yards_after_contact', 'separation', 'contested_catch_rate',
+  'route_participation', 'red_zone_targets',
+])
+
+export const ClaimPartsSchema = z.object({
+  metrics: z.array(MetricSchema).min(1),
+  direction: z.enum(['positive', 'negative', 'neutral']),
+  comparator: z.enum(['ranks', 'exceeds', 'trails', 'matches', 'diverges_from']),
+  rank_or_percentile: z.object({
+    type: z.enum(['rank', 'percentile']),
+    value: z.number(),
+    scope: z.enum(['league', 'position', 'conference', 'division']),
+    direction: z.enum(['top', 'bottom']),
+  }).strict().optional(),
+  comparison_target: z.enum([
+    'league_average', 'opponent_average', 'position_average',
+    'season_baseline', 'historical_self'
+  ]).optional(),
+  context_qualifier: z.enum([
+    'in_division', 'at_home', 'as_underdog', 'in_primetime',
+    'vs_top_10_defense', 'with_current_qb'
+  ]).optional(),
+}).strict()
+
+export type ClaimParts = z.infer<typeof ClaimPartsSchema>
+
+// Render claim parts to string
+const METRIC_DISPLAY: Record<string, string> = {
+  receiving_epa: 'Receiving EPA',
+  rushing_epa: 'Rushing EPA',
+  pass_block_win_rate: 'Pass Block Win Rate',
+  pressure_rate: 'Pressure Rate',
+  target_share: 'Target Share',
+  snap_count: 'Snap Count',
+  red_zone_epa: 'Red Zone EPA',
+  epa_allowed: 'EPA Allowed',
+  completion_rate: 'Completion Rate',
+  yards_per_attempt: 'Yards Per Attempt',
+  sack_rate: 'Sack Rate',
+  passer_rating: 'Passer Rating',
+  yards_after_contact: 'Yards After Contact',
+  separation: 'Separation',
+  contested_catch_rate: 'Contested Catch Rate',
+  route_participation: 'Route Participation',
+  red_zone_targets: 'Red Zone Targets',
+}
+
+const COMPARISON_DISPLAY: Record<string, string> = {
+  league_average: 'league average',
+  opponent_average: 'opponent average',
+  position_average: 'position average',
+  season_baseline: 'season baseline',
+  historical_self: 'historical self',
+}
+
+const QUALIFIER_DISPLAY: Record<string, string> = {
+  in_division: 'in division games',
+  at_home: 'at home',
+  as_underdog: 'as underdog',
+  in_primetime: 'in primetime',
+  vs_top_10_defense: 'vs top 10 defense',
+  with_current_qb: 'with current QB',
+}
+
+export function renderClaim(parts: ClaimParts): string {
+  const metricNames = parts.metrics.map(m => METRIC_DISPLAY[m] || m).join(' + ')
+
+  let claim = metricNames
+
+  if (parts.rank_or_percentile) {
+    const r = parts.rank_or_percentile
+    claim += ` ${parts.comparator} ${r.direction} ${r.value}`
+    claim += r.type === 'rank' ? ` in ${r.scope}` : 'th percentile'
+  }
+
+  if (parts.comparison_target) {
+    claim += ` vs ${COMPARISON_DISPLAY[parts.comparison_target]}`
+  }
+
+  if (parts.context_qualifier) {
+    claim += ` (${QUALIFIER_DISPLAY[parts.context_qualifier]})`
+  }
+
+  return claim
+}
+```
+
+**Step 12: Run test to verify it passes**
+
+Run: `npm test -- --run __tests__/terminal/schemas.test.ts`
+Expected: PASS
+
+**Step 13: Write failing test for Alert schema**
+
+Add to `__tests__/terminal/schemas.test.ts`:
+```typescript
+import { AlertSchema } from '@/lib/terminal/schemas'
+
+describe('AlertSchema', () => {
+  it('accepts valid alert', () => {
+    const alert = {
+      id: 'epa-jsn-recv-001',
+      agent: 'epa' as const,
+      evidence: [{
+        stat: 'receiving_epa_rank',
+        value_num: 3,
+        value_type: 'numeric' as const,
+        comparison: 'top 5 in league',
+        source_type: 'local' as const,
+        source_ref: 'local://data/epa/week-20.json',
+      }],
+      sources: [{
+        type: 'local' as const,
+        ref: 'local://data/epa/week-20.json',
+        data_version: '2025-week-20',
+        data_timestamp: Date.now(),
+      }],
+      confidence: 0.75,
+      freshness: 'weekly' as const,
+      severity: 'high' as const,
+      claim: 'Receiving EPA ranks top 5 in league',
+      implications: ['wr_receptions_over', 'wr_yards_over'],
+      suppressions: [],
+    }
+    expect(() => AlertSchema.parse(alert)).not.toThrow()
+  })
+
+  it('rejects confidence outside 0-1 range', () => {
+    const alert = {
+      id: 'test',
+      agent: 'epa' as const,
+      evidence: [],
+      sources: [],
+      confidence: 1.5, // invalid
+      freshness: 'weekly' as const,
+      severity: 'high' as const,
+      claim: 'test',
+      implications: [],
+      suppressions: [],
+    }
+    expect(() => AlertSchema.parse(alert)).toThrow()
+  })
+})
+```
+
+**Step 14: Run test to verify it fails**
+
+Run: `npm test -- --run __tests__/terminal/schemas.test.ts`
+Expected: FAIL (AlertSchema not found)
+
+**Step 15: Create Alert schema**
+
+```typescript
+// lib/terminal/schemas/alert.ts
+import { z } from 'zod'
+import { EvidenceSchema, LineEvidenceSchema } from './evidence'
+import { AgentTypeSchema } from './finding'
+
+export const SourceSchema = z.object({
+  type: z.enum(['local', 'web', 'line']),
+  ref: z.string(),
+  data_version: z.string(),
+  data_timestamp: z.number(),
+  search_timestamp: z.number().optional(),
+  quote_snippet: z.string().optional(),
+}).strict()
+
+export const AlertSchema = z.object({
+  // From code (immutable)
+  id: z.string(),
+  agent: AgentTypeSchema,
+  evidence: z.array(z.union([EvidenceSchema, LineEvidenceSchema])).min(1),
+  sources: z.array(SourceSchema).min(1),
+  confidence: z.number().min(0).max(1),
+  freshness: z.enum(['live', 'weekly', 'stale']),
+
+  // From LLM (constrained)
+  severity: z.enum(['high', 'medium']),
+  claim: z.string().max(200),
+  implications: z.array(z.string()).min(1).max(5),
+  suppressions: z.array(z.string()),
+}).strict()
+
+export type Source = z.infer<typeof SourceSchema>
+export type Alert = z.infer<typeof AlertSchema>
+```
+
+**Step 16: Run test to verify it passes**
+
+Run: `npm test -- --run __tests__/terminal/schemas.test.ts`
+Expected: PASS
+
+**Step 17: Create Provenance schema**
+
+```typescript
+// lib/terminal/schemas/provenance.ts
+import { z } from 'zod'
+import { AgentTypeSchema } from './finding'
+
+export const ProvenanceSchema = z.object({
+  request_id: z.string(),
+  prompt_hash: z.string(),
+  skill_md_hashes: z.record(AgentTypeSchema, z.string()),
+  findings_hash: z.string(),
+  data_version: z.string(),
+  data_timestamp: z.number(),
+  search_timestamps: z.array(z.number()),
+  agents_invoked: z.array(AgentTypeSchema),
+  agents_silent: z.array(AgentTypeSchema),
+  cache_hits: z.number(),
+  cache_misses: z.number(),
+  llm_model: z.string(),
+  llm_temperature: z.number(),
+}).strict()
+
+export type Provenance = z.infer<typeof ProvenanceSchema>
+```
+
+**Step 18: Create LLM output schema**
+
+```typescript
+// lib/terminal/schemas/llm-output.ts
+import { z } from 'zod'
+import { ClaimPartsSchema } from './claim'
+
+// What LLM outputs - keyed by finding_id
+export const LLMFindingOutputSchema = z.object({
+  severity: z.enum(['high', 'medium']),
+  claim_parts: ClaimPartsSchema,
+  implications: z.array(z.string()),
+  suppressions: z.array(z.string()),
+}).strict()
+
+export const LLMOutputSchema = z.record(z.string(), LLMFindingOutputSchema)
+
+export type LLMFindingOutput = z.infer<typeof LLMFindingOutputSchema>
+export type LLMOutput = z.infer<typeof LLMOutputSchema>
+```
+
+**Step 19: Create index file**
+
+```typescript
+// lib/terminal/schemas/index.ts
+export * from './evidence'
+export * from './finding'
+export * from './alert'
+export * from './claim'
+export * from './provenance'
+export * from './llm-output'
+```
+
+**Step 20: Run all schema tests**
+
+Run: `npm test -- --run __tests__/terminal/schemas.test.ts`
+Expected: PASS (all tests)
+
+**Step 21: Commit**
+
+```bash
+git add lib/terminal/schemas/ __tests__/terminal/schemas.test.ts vitest.config.ts package.json
+git commit -m "feat(terminal): add core Zod schemas with strict validation"
+```
+
+---
+
+## Task 2: Validators
+
+**Files:**
+- Create: `lib/terminal/engine/validators.ts`
+- Create: `lib/terminal/engine/implications.ts`
+- Create: `lib/terminal/engine/line-freshness.ts`
+- Test: `__tests__/terminal/validators.test.ts`
+
+**Step 1: Write failing test for source integrity validation**
+
+```typescript
+// __tests__/terminal/validators.test.ts
+import { describe, it, expect } from 'vitest'
+import { validateSourceIntegrity } from '@/lib/terminal/engine/validators'
+import type { Alert } from '@/lib/terminal/schemas'
+
+describe('validateSourceIntegrity', () => {
+  it('passes when all evidence refs have sources', () => {
+    const alert: Alert = {
+      id: 'test-001',
+      agent: 'epa',
+      evidence: [{
+        stat: 'receiving_epa',
+        value_num: 0.31,
+        value_type: 'numeric',
+        comparison: 'top 5',
+        source_type: 'local',
+        source_ref: 'local://data/epa/week-20.json',
+      }],
+      sources: [{
+        type: 'local',
+        ref: 'local://data/epa/week-20.json',
+        data_version: '2025-week-20',
+        data_timestamp: Date.now(),
+      }],
+      confidence: 0.75,
+      freshness: 'weekly',
+      severity: 'high',
+      claim: 'test claim',
+      implications: ['wr_receptions_over'],
+      suppressions: [],
+    }
+    expect(() => validateSourceIntegrity(alert)).not.toThrow()
+  })
+
+  it('rejects orphan sources', () => {
+    const alert: Alert = {
+      id: 'test-001',
+      agent: 'epa',
+      evidence: [{
+        stat: 'receiving_epa',
+        value_num: 0.31,
+        value_type: 'numeric',
+        comparison: 'top 5',
+        source_type: 'local',
+        source_ref: 'local://data/epa/week-20.json',
+      }],
+      sources: [
+        {
+          type: 'local',
+          ref: 'local://data/epa/week-20.json',
+          data_version: '2025-week-20',
+          data_timestamp: Date.now(),
+        },
+        {
+          type: 'web',
+          ref: 'https://orphan.com', // orphan - not in evidence
+          data_version: '2025-week-20',
+          data_timestamp: Date.now(),
+          search_timestamp: Date.now(),
+          quote_snippet: 'orphan',
+        },
+      ],
+      confidence: 0.75,
+      freshness: 'weekly',
+      severity: 'high',
+      claim: 'test claim',
+      implications: ['wr_receptions_over'],
+      suppressions: [],
+    }
+    expect(() => validateSourceIntegrity(alert)).toThrow(/orphan/i)
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run __tests__/terminal/validators.test.ts`
+Expected: FAIL (module not found)
+
+**Step 3: Create validators module**
+
+```typescript
+// lib/terminal/engine/validators.ts
+import type { Alert, Finding, LLMFindingOutput } from '../schemas'
+import { AlertSchema, ClaimPartsSchema } from '../schemas'
+import { validateImplications } from './implications'
+import { validateLineEvidence } from './line-freshness'
+import { calculateConfidence } from './confidence'
+
+export function validateSourceIntegrity(alert: Alert): void {
+  const evidenceRefs = new Set(alert.evidence.map(e => e.source_ref))
+  const sourceRefs = new Set(alert.sources.map(s => s.ref))
+
+  // No orphan sources
+  for (const ref of sourceRefs) {
+    if (!evidenceRefs.has(ref)) {
+      throw new Error(`Orphan source: ${ref} not referenced in evidence`)
+    }
+  }
+
+  // All evidence refs have corresponding source
+  for (const ref of evidenceRefs) {
+    if (!sourceRefs.has(ref)) {
+      throw new Error(`Missing source for evidence ref: ${ref}`)
+    }
+  }
+}
+
+// Edge language that requires LineEvidence
+const EDGE_LANGUAGE = [
+  /\bedge\b/i, /\bvalue\b/i, /\bmispriced\b/i,
+  /\bexploit\b/i, /\bsharp\b/i, /\block\b/i,
+]
+
+export function validateNoEdgeWithoutLine(alert: Alert): void {
+  const hasLineEvidence = alert.evidence.some(e => 'line_type' in e)
+
+  for (const pattern of EDGE_LANGUAGE) {
+    if (pattern.test(alert.claim) && !hasLineEvidence) {
+      throw new Error(`Claim uses edge language "${pattern}" but no LineEvidence provided`)
+    }
+  }
+}
+
+export function validateAlert(
+  finding: Finding,
+  llmOutput: LLMFindingOutput,
+  alert: Alert
+): void {
+  // 1. Zod strict parse (no extra fields)
+  AlertSchema.parse(alert)
+
+  // 2. ID/Agent immutability (code-assigned, not LLM)
+  if (alert.id !== finding.id) {
+    throw new Error(`ID mismatch: expected ${finding.id}, got ${alert.id}`)
+  }
+  if (alert.agent !== finding.agent) {
+    throw new Error(`Agent mismatch: expected ${finding.agent}, got ${alert.agent}`)
+  }
+
+  // 3. Confidence immutability (code-derived)
+  const expectedConfidence = calculateConfidence(finding)
+  if (Math.abs(alert.confidence - expectedConfidence) > 0.001) {
+    throw new Error(`Confidence was modified: expected ${expectedConfidence}, got ${alert.confidence}`)
+  }
+
+  // 4. Source integrity (no orphans)
+  validateSourceIntegrity(alert)
+
+  // 5. Line freshness (if applicable)
+  validateLineEvidence(alert)
+
+  // 6. Claim parts valid (structured, not free text)
+  ClaimPartsSchema.parse(llmOutput.claim_parts)
+
+  // 7. Implications allowlist
+  validateImplications(alert.agent, finding.type, alert.implications)
+
+  // 8. No edge language without LineEvidence
+  validateNoEdgeWithoutLine(alert)
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm test -- --run __tests__/terminal/validators.test.ts`
+Expected: PASS
+
+**Step 5: Write failing test for implications validation**
+
+Add to `__tests__/terminal/validators.test.ts`:
+```typescript
+import { validateImplications, AGENT_IMPLICATIONS } from '@/lib/terminal/engine/implications'
+
+describe('validateImplications', () => {
+  it('accepts valid implications for agent', () => {
+    expect(() => validateImplications('epa', 'receiving_epa_mismatch', ['wr_receptions_over'])).not.toThrow()
+  })
+
+  it('rejects implications not in agent allowlist', () => {
+    expect(() => validateImplications('weather', 'wind_advisory', ['qb_pass_tds_over'])).toThrow()
+  })
+})
+```
+
+**Step 6: Run test to verify it fails**
+
+Run: `npm test -- --run __tests__/terminal/validators.test.ts`
+Expected: FAIL (validateImplications not found)
+
+**Step 7: Create implications module**
+
+```typescript
+// lib/terminal/engine/implications.ts
+import type { AgentType } from '../schemas'
+
+export const AGENT_IMPLICATIONS: Record<AgentType, string[]> = {
+  epa: [
+    'wr_receptions_over', 'wr_receptions_under',
+    'wr_yards_over', 'wr_yards_under',
+    'rb_yards_over', 'rb_yards_under',
+    'team_total_over', 'team_total_under',
+  ],
+  pressure: [
+    'qb_sacks_over', 'qb_sacks_under',
+    'qb_ints_over', 'qb_pass_yards_under',
+    'def_sacks_over',
+  ],
+  weather: [
+    'game_total_under', 'pass_yards_under', 'field_goals_over',
+  ],
+  qb: [
+    'qb_pass_yards_over', 'qb_pass_yards_under',
+    'qb_pass_tds_over', 'qb_pass_tds_under',
+    'qb_completions_over', 'qb_completions_under',
+    'qb_ints_over',
+  ],
+  hb: [
+    'rb_rush_yards_over', 'rb_rush_yards_under',
+    'rb_receptions_over', 'rb_rush_attempts_over',
+    'rb_tds_over',
+  ],
+  wr: [
+    'wr_receptions_over', 'wr_receptions_under',
+    'wr_yards_over', 'wr_yards_under',
+    'wr_tds_over', 'wr_longest_reception_over',
+  ],
+  te: [
+    'te_receptions_over', 'te_receptions_under',
+    'te_yards_over', 'te_yards_under',
+    'te_tds_over',
+  ],
+}
+
+// Finding type → allowed implications
+export const FINDING_TO_IMPLICATIONS: Record<string, string[]> = {
+  receiving_epa_mismatch: ['wr_receptions_over', 'wr_yards_over', 'te_receptions_over'],
+  rushing_epa_mismatch: ['rb_yards_over', 'rb_rush_attempts_over'],
+  pressure_rate_advantage: ['qb_sacks_over', 'qb_ints_over', 'qb_pass_yards_under', 'def_sacks_over'],
+  weather_wind: ['game_total_under', 'pass_yards_under', 'field_goals_over'],
+  weather_cold: ['game_total_under', 'pass_yards_under'],
+  weather_rain: ['game_total_under', 'pass_yards_under', 'rb_yards_over'],
+  qb_efficiency_edge: ['qb_pass_yards_over', 'qb_pass_tds_over', 'qb_completions_over'],
+  qb_pressure_vulnerability: ['qb_ints_over', 'qb_sacks_over', 'qb_pass_yards_under'],
+  rb_workload_increase: ['rb_rush_yards_over', 'rb_rush_attempts_over', 'rb_tds_over'],
+  rb_receiving_role: ['rb_receptions_over', 'rb_yards_over'],
+  wr_target_share: ['wr_receptions_over', 'wr_yards_over', 'wr_tds_over'],
+  wr_matchup_advantage: ['wr_yards_over', 'wr_longest_reception_over'],
+  te_red_zone_role: ['te_receptions_over', 'te_tds_over'],
+}
+
+export function validateImplications(
+  agent: AgentType,
+  findingType: string,
+  implications: string[]
+): void {
+  const allowedByAgent = AGENT_IMPLICATIONS[agent]
+  const allowedByFinding = FINDING_TO_IMPLICATIONS[findingType] || allowedByAgent // fallback to agent allowlist
+
+  for (const imp of implications) {
+    if (!allowedByAgent.includes(imp)) {
+      throw new Error(`Agent ${agent} cannot imply market: ${imp}`)
+    }
+    if (!allowedByFinding.includes(imp)) {
+      throw new Error(`Finding ${findingType} does not justify implication: ${imp}`)
+    }
+  }
+}
+```
+
+**Step 8: Run test to verify it passes**
+
+Run: `npm test -- --run __tests__/terminal/validators.test.ts`
+Expected: PASS
+
+**Step 9: Write failing test for line freshness**
+
+Add to `__tests__/terminal/validators.test.ts`:
+```typescript
+import { validateLineEvidence, LINE_TTL, isLineFresh } from '@/lib/terminal/engine/line-freshness'
+import type { LineEvidence } from '@/lib/terminal/schemas'
+
+describe('line freshness', () => {
+  it('accepts fresh line evidence', () => {
+    const lineEvidence: LineEvidence = {
+      stat: 'spread',
+      value_num: -3.5,
+      value_type: 'numeric',
+      comparison: 'current',
+      source_type: 'line',
+      source_ref: 'https://book.com',
+      line_type: 'spread',
+      line_value: -3.5,
+      line_odds: -110,
+      book: 'DraftKings',
+      line_timestamp: Date.now() - 5 * 60 * 1000, // 5 min ago
+      line_ttl: LINE_TTL.spread,
+    }
+    expect(isLineFresh(lineEvidence)).toBe(true)
+  })
+
+  it('rejects stale line evidence', () => {
+    const lineEvidence: LineEvidence = {
+      stat: 'spread',
+      value_num: -3.5,
+      value_type: 'numeric',
+      comparison: 'current',
+      source_type: 'line',
+      source_ref: 'https://book.com',
+      line_type: 'spread',
+      line_value: -3.5,
+      line_odds: -110,
+      book: 'DraftKings',
+      line_timestamp: Date.now() - 60 * 60 * 1000, // 1 hour ago
+      line_ttl: LINE_TTL.spread, // 30 min TTL
+    }
+    expect(isLineFresh(lineEvidence)).toBe(false)
+  })
+})
+```
+
+**Step 10: Run test to verify it fails**
+
+Run: `npm test -- --run __tests__/terminal/validators.test.ts`
+Expected: FAIL (module not found)
+
+**Step 11: Create line freshness module**
+
+```typescript
+// lib/terminal/engine/line-freshness.ts
+import type { Alert, LineEvidence } from '../schemas'
+
+export const LINE_TTL = {
+  spread: 30 * 60 * 1000,      // 30 min
+  total: 30 * 60 * 1000,       // 30 min
+  prop: 15 * 60 * 1000,        // 15 min (more volatile)
+  moneyline: 60 * 60 * 1000,   // 1 hr
+} as const
+
+export function isLineFresh(evidence: LineEvidence): boolean {
+  const ttl = LINE_TTL[evidence.line_type]
+  const age = Date.now() - evidence.line_timestamp
+  return age < ttl
+}
+
+export function validateLineEvidence(alert: Alert): void {
+  const lineEvidence = alert.evidence.filter(
+    (e): e is LineEvidence => 'line_type' in e
+  )
+
+  for (const le of lineEvidence) {
+    if (!isLineFresh(le)) {
+      const age = Date.now() - le.line_timestamp
+      throw new Error(
+        `Stale line evidence: ${le.line_type} is ${Math.round(age / 1000 / 60)}min old (TTL: ${LINE_TTL[le.line_type] / 1000 / 60}min)`
+      )
+    }
+  }
+}
+```
+
+**Step 12: Run test to verify it passes**
+
+Run: `npm test -- --run __tests__/terminal/validators.test.ts`
+Expected: PASS
+
+**Step 13: Commit**
+
+```bash
+git add lib/terminal/engine/ __tests__/terminal/validators.test.ts
+git commit -m "feat(terminal): add validators for source integrity, implications, line freshness"
+```
+
+---
+
+## Task 3: Confidence Calculation
+
+**Files:**
+- Create: `lib/terminal/engine/confidence.ts`
+- Test: `__tests__/terminal/confidence.test.ts`
+
+**Step 1: Write failing test**
+
+```typescript
+// __tests__/terminal/confidence.test.ts
+import { describe, it, expect } from 'vitest'
+import { calculateConfidence, type ConfidenceInputs } from '@/lib/terminal/engine/confidence'
+
+describe('calculateConfidence', () => {
+  it('returns baseline 0.5 with minimal inputs', () => {
+    const inputs: ConfidenceInputs = {
+      evidenceCount: 1,
+      hasLocalSource: false,
+      hasWebSource: false,
+      webSourceAge: null,
+      localDataAge: 0,
+      sampleSize: null,
+      hasLineEvidence: false,
+      lineAge: null,
+    }
+    const confidence = calculateConfidence(inputs)
+    expect(confidence).toBeCloseTo(0.5, 2)
+  })
+
+  it('increases with multiple evidence', () => {
+    const inputs: ConfidenceInputs = {
+      evidenceCount: 3,
+      hasLocalSource: true,
+      hasWebSource: false,
+      webSourceAge: null,
+      localDataAge: 0,
+      sampleSize: 100,
+      hasLineEvidence: false,
+      lineAge: null,
+    }
+    const confidence = calculateConfidence(inputs)
+    expect(confidence).toBeGreaterThan(0.8)
+  })
+
+  it('decreases with stale data', () => {
+    const inputs: ConfidenceInputs = {
+      evidenceCount: 2,
+      hasLocalSource: true,
+      hasWebSource: false,
+      webSourceAge: null,
+      localDataAge: 10 * 24 * 3600 * 1000, // 10 days
+      sampleSize: null,
+      hasLineEvidence: false,
+      lineAge: null,
+    }
+    const confidence = calculateConfidence(inputs)
+    expect(confidence).toBeLessThan(0.5)
+  })
+
+  it('clamps to 0-1 range', () => {
+    const highInputs: ConfidenceInputs = {
+      evidenceCount: 5,
+      hasLocalSource: true,
+      hasWebSource: true,
+      webSourceAge: 1000,
+      localDataAge: 0,
+      sampleSize: 200,
+      hasLineEvidence: true,
+      lineAge: 1000,
+    }
+    expect(calculateConfidence(highInputs)).toBeLessThanOrEqual(1)
+    expect(calculateConfidence(highInputs)).toBeGreaterThanOrEqual(0)
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run __tests__/terminal/confidence.test.ts`
+Expected: FAIL (module not found)
+
+**Step 3: Create confidence module**
+
+```typescript
+// lib/terminal/engine/confidence.ts
+import type { Finding } from '../schemas'
+
+export interface ConfidenceInputs {
+  evidenceCount: number
+  hasLocalSource: boolean
+  hasWebSource: boolean
+  webSourceAge: number | null       // ms since search
+  localDataAge: number              // ms since data_timestamp
+  sampleSize: number | null         // e.g. targets, snaps
+  hasLineEvidence: boolean
+  lineAge: number | null            // ms since line_timestamp
+}
+
+export function calculateConfidence(inputs: ConfidenceInputs): number {
+  let score = 0.5  // baseline
+
+  // Evidence quantity
+  if (inputs.evidenceCount >= 3) score += 0.15
+  else if (inputs.evidenceCount >= 2) score += 0.08
+
+  // Source quality
+  if (inputs.hasLocalSource) score += 0.10
+  if (inputs.hasWebSource && inputs.webSourceAge !== null && inputs.webSourceAge < 4 * 3600 * 1000) {
+    score += 0.08  // fresh web
+  }
+
+  // Sample size (if applicable)
+  if (inputs.sampleSize !== null) {
+    if (inputs.sampleSize >= 100) score += 0.12
+    else if (inputs.sampleSize >= 50) score += 0.06
+    else score -= 0.10  // penalty for small sample
+  }
+
+  // Line freshness (if betting relevance claimed)
+  if (inputs.hasLineEvidence && inputs.lineAge !== null) {
+    if (inputs.lineAge < 30 * 60 * 1000) score += 0.10  // <30min
+    else if (inputs.lineAge < 2 * 3600 * 1000) score += 0.05  // <2hr
+    else score -= 0.15  // stale line penalty
+  }
+
+  // Data freshness
+  if (inputs.localDataAge > 7 * 24 * 3600 * 1000) score -= 0.20  // >7 days old
+
+  return Math.max(0, Math.min(1, score))
+}
+
+// Helper to derive confidence inputs from a Finding
+export function confidenceInputsFromFinding(finding: Finding): ConfidenceInputs {
+  const now = Date.now()
+  return {
+    evidenceCount: 1, // Single finding = 1 evidence piece
+    hasLocalSource: finding.source_type === 'local',
+    hasWebSource: finding.source_type === 'web',
+    webSourceAge: finding.source_type === 'web' ? now - finding.source_timestamp : null,
+    localDataAge: finding.source_type === 'local' ? now - finding.source_timestamp : 0,
+    sampleSize: null, // Would need to be passed from threshold logic
+    hasLineEvidence: false,
+    lineAge: null,
+  }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm test -- --run __tests__/terminal/confidence.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add lib/terminal/engine/confidence.ts __tests__/terminal/confidence.test.ts
+git commit -m "feat(terminal): add code-derived confidence calculation"
+```
+
+---
+
+## Task 4: Provenance & Hashing
+
+**Files:**
+- Create: `lib/terminal/engine/provenance.ts`
+- Test: `__tests__/terminal/provenance.test.ts`
+
+**Step 1: Write failing test**
+
+```typescript
+// __tests__/terminal/provenance.test.ts
+import { describe, it, expect } from 'vitest'
+import { hashContent, buildProvenance } from '@/lib/terminal/engine/provenance'
+import type { Finding } from '@/lib/terminal/schemas'
+
+describe('hashContent', () => {
+  it('produces consistent hashes', () => {
+    const content = 'test content'
+    const hash1 = hashContent(content)
+    const hash2 = hashContent(content)
+    expect(hash1).toBe(hash2)
+  })
+
+  it('produces different hashes for different content', () => {
+    const hash1 = hashContent('content A')
+    const hash2 = hashContent('content B')
+    expect(hash1).not.toBe(hash2)
+  })
+
+  it('returns 12-character hash', () => {
+    const hash = hashContent('test')
+    expect(hash).toHaveLength(12)
+  })
+})
+
+describe('buildProvenance', () => {
+  it('builds complete provenance object', () => {
+    const findings: Finding[] = [{
+      id: 'test-001',
+      agent: 'epa',
+      type: 'receiving_epa_mismatch',
+      stat: 'receiving_epa',
+      value_num: 0.31,
+      value_type: 'numeric',
+      threshold_met: 'rank <= 10',
+      comparison_context: 'top 5',
+      source_ref: 'local://data/epa/week-20.json',
+      source_type: 'local',
+      source_timestamp: Date.now(),
+    }]
+
+    const provenance = buildProvenance({
+      requestId: 'req-123',
+      prompt: 'test prompt',
+      skillMds: { epa: '# EPA Agent\n...' },
+      findings,
+      dataVersion: '2025-week-20',
+      dataTimestamp: Date.now(),
+      searchTimestamps: [],
+      agentsInvoked: ['epa'],
+      agentsSilent: ['weather', 'pressure'],
+      cacheHits: 1,
+      cacheMisses: 0,
+      llmModel: 'gpt-4o',
+      llmTemperature: 0,
+    })
+
+    expect(provenance.request_id).toBe('req-123')
+    expect(provenance.prompt_hash).toHaveLength(12)
+    expect(provenance.findings_hash).toHaveLength(12)
+    expect(provenance.skill_md_hashes.epa).toHaveLength(12)
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run __tests__/terminal/provenance.test.ts`
+Expected: FAIL (module not found)
+
+**Step 3: Create provenance module**
+
+```typescript
+// lib/terminal/engine/provenance.ts
+import { createHash } from 'crypto'
+import type { Finding, AgentType, Provenance } from '../schemas'
+
+export function hashContent(content: string): string {
+  return createHash('sha256').update(content).digest('hex').slice(0, 12)
+}
+
+interface BuildProvenanceInput {
+  requestId: string
+  prompt: string
+  skillMds: Partial<Record<AgentType, string>>
+  findings: Finding[]
+  dataVersion: string
+  dataTimestamp: number
+  searchTimestamps: number[]
+  agentsInvoked: AgentType[]
+  agentsSilent: AgentType[]
+  cacheHits: number
+  cacheMisses: number
+  llmModel: string
+  llmTemperature: number
+}
+
+export function buildProvenance(inputs: BuildProvenanceInput): Provenance {
+  const skillMdHashes = Object.fromEntries(
+    Object.entries(inputs.skillMds).map(([k, v]) => [k, hashContent(v as string)])
+  ) as Record<AgentType, string>
+
+  return {
+    request_id: inputs.requestId,
+    prompt_hash: hashContent(inputs.prompt),
+    skill_md_hashes: skillMdHashes,
+    findings_hash: hashContent(JSON.stringify(inputs.findings)),
+    data_version: inputs.dataVersion,
+    data_timestamp: inputs.dataTimestamp,
+    search_timestamps: inputs.searchTimestamps,
+    agents_invoked: inputs.agentsInvoked,
+    agents_silent: inputs.agentsSilent,
+    cache_hits: inputs.cacheHits,
+    cache_misses: inputs.cacheMisses,
+    llm_model: inputs.llmModel,
+    llm_temperature: inputs.llmTemperature,
+  }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm test -- --run __tests__/terminal/provenance.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add lib/terminal/engine/provenance.ts __tests__/terminal/provenance.test.ts
+git commit -m "feat(terminal): add provenance building with reproducibility hashes"
+```
+
+---
+
+## Task 5: Guardrails & Streaming
+
+**Files:**
+- Create: `lib/terminal/engine/guardrails.ts`
+- Create: `lib/terminal/engine/fallback-renderer.ts`
+- Test: `__tests__/terminal/guardrails.test.ts`
+
+**Step 1: Write failing test for guardrails**
+
+```typescript
+// __tests__/terminal/guardrails.test.ts
+import { describe, it, expect } from 'vitest'
+import { REQUEST_LIMITS, STREAM_CONFIG, checkRequestLimits } from '@/lib/terminal/engine/guardrails'
+
+describe('REQUEST_LIMITS', () => {
+  it('has sensible defaults', () => {
+    expect(REQUEST_LIMITS.maxInputTokens).toBe(8000)
+    expect(REQUEST_LIMITS.maxOutputTokens).toBe(2000)
+    expect(REQUEST_LIMITS.maxCostPerRequest).toBe(0.15)
+    expect(REQUEST_LIMITS.timeoutMs).toBe(45000)
+  })
+})
+
+describe('checkRequestLimits', () => {
+  it('passes for small requests', () => {
+    expect(() => checkRequestLimits({ inputTokens: 1000 })).not.toThrow()
+  })
+
+  it('rejects requests exceeding token limit', () => {
+    expect(() => checkRequestLimits({ inputTokens: 10000 })).toThrow(/token/i)
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run __tests__/terminal/guardrails.test.ts`
+Expected: FAIL (module not found)
+
+**Step 3: Create guardrails module**
+
+```typescript
+// lib/terminal/engine/guardrails.ts
+
+export const REQUEST_LIMITS = {
+  maxInputTokens: 8000,
+  maxOutputTokens: 2000,
+  maxCostPerRequest: 0.15,  // $0.15 USD
+  timeoutMs: 45000,         // 45s
+} as const
+
+export const STREAM_CONFIG = {
+  heartbeatIntervalMs: 3000,
+  heartbeatPayload: { type: 'heartbeat' as const, status: 'processing' as const },
+} as const
+
+export const SEARCH_CONFIG = {
+  enabled: true,
+  budgetPerMatchup: 5,
+  budgetPerAgent: 2,
+  cacheTTL: 3600 * 4,  // 4 hours
+  noiseThreshold: 0.3,
+} as const
+
+interface RequestCheckInput {
+  inputTokens: number
+  estimatedCost?: number
+}
+
+export function checkRequestLimits(input: RequestCheckInput): void {
+  if (input.inputTokens > REQUEST_LIMITS.maxInputTokens) {
+    throw new Error(`Input tokens (${input.inputTokens}) exceeds limit (${REQUEST_LIMITS.maxInputTokens})`)
+  }
+  if (input.estimatedCost && input.estimatedCost > REQUEST_LIMITS.maxCostPerRequest) {
+    throw new Error(`Estimated cost ($${input.estimatedCost}) exceeds limit ($${REQUEST_LIMITS.maxCostPerRequest})`)
+  }
+}
+
+// Heartbeat generator for streaming
+export async function* heartbeatGenerator<T>(
+  source: AsyncIterable<T>,
+  intervalMs: number = STREAM_CONFIG.heartbeatIntervalMs
+): AsyncIterable<T | typeof STREAM_CONFIG.heartbeatPayload> {
+  let lastYield = Date.now()
+
+  for await (const item of source) {
+    yield item
+    lastYield = Date.now()
+  }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm test -- --run __tests__/terminal/guardrails.test.ts`
+Expected: PASS
+
+**Step 5: Write failing test for fallback renderer**
+
+Add to `__tests__/terminal/guardrails.test.ts`:
+```typescript
+import { renderFindingsFallback } from '@/lib/terminal/engine/fallback-renderer'
+import type { Finding } from '@/lib/terminal/schemas'
+
+describe('renderFindingsFallback', () => {
+  it('renders findings without LLM', () => {
+    const findings: Finding[] = [{
+      id: 'epa-001',
+      agent: 'epa',
+      type: 'receiving_epa_mismatch',
+      stat: 'receiving_epa_rank',
+      value_num: 3,
+      value_type: 'numeric',
+      threshold_met: 'rank <= 10',
+      comparison_context: '3rd in league',
+      source_ref: 'local://data/epa/week-20.json',
+      source_type: 'local',
+      source_timestamp: Date.now(),
+    }]
+
+    const output = renderFindingsFallback(findings)
+
+    expect(output).toHaveLength(1)
+    expect(output[0].agent).toBe('epa')
+    expect(output[0].line).toContain('receiving_epa_rank')
+    expect(output[0].line).toContain('3')
+    expect(output[0].severity).toBe('raw')
+  })
+})
+```
+
+**Step 6: Run test to verify it fails**
+
+Run: `npm test -- --run __tests__/terminal/guardrails.test.ts`
+Expected: FAIL (renderFindingsFallback not found)
+
+**Step 7: Create fallback renderer**
+
+```typescript
+// lib/terminal/engine/fallback-renderer.ts
+import type { Finding, AgentType } from '../schemas'
+
+export interface FallbackLine {
+  agent: AgentType
+  line: string
+  source: string
+  severity: 'raw'
+}
+
+export function renderFindingsFallback(findings: Finding[]): FallbackLine[] {
+  return findings.map(f => ({
+    agent: f.agent,
+    line: `${f.stat}: ${f.value_num ?? f.value_str} (${f.comparison_context})`,
+    source: f.source_ref,
+    severity: 'raw' as const,
+  }))
+}
+
+export function formatFallbackForTerminal(lines: FallbackLine[]): string {
+  const header = '⚠️  Analyst offline. Raw findings:\n'
+  const body = lines.map(l =>
+    `   [${l.agent}] ${l.line}\n         → ${l.source}`
+  ).join('\n\n')
+  const footer = '\n\n   Type "retry" or "build --raw" to continue.'
+
+  return header + '\n' + body + footer
+}
+```
+
+**Step 8: Run test to verify it passes**
+
+Run: `npm test -- --run __tests__/terminal/guardrails.test.ts`
+Expected: PASS
+
+**Step 9: Commit**
+
+```bash
+git add lib/terminal/engine/guardrails.ts lib/terminal/engine/fallback-renderer.ts __tests__/terminal/guardrails.test.ts
+git commit -m "feat(terminal): add request guardrails and fallback renderer"
+```
+
+---
+
+## Task 6: EPA Agent Thresholds
+
+**Files:**
+- Create: `lib/terminal/agents/epa/thresholds.ts`
+- Create: `lib/terminal/agents/epa/skill.md`
+- Test: `__tests__/terminal/agents/epa.test.ts`
+
+**Step 1: Write failing test**
+
+```typescript
+// __tests__/terminal/agents/epa.test.ts
+import { describe, it, expect } from 'vitest'
+import { EPA_THRESHOLDS, checkEpaThresholds } from '@/lib/terminal/agents/epa/thresholds'
+import type { Finding } from '@/lib/terminal/schemas'
+
+describe('EPA_THRESHOLDS', () => {
+  it('has defined threshold values', () => {
+    expect(EPA_THRESHOLDS.receivingEpaRank).toBe(10)
+    expect(EPA_THRESHOLDS.epaAllowedRank).toBe(10)
+    expect(EPA_THRESHOLDS.rushingEpaDiff).toBe(0.15)
+  })
+})
+
+describe('checkEpaThresholds', () => {
+  it('returns finding when receiving EPA rank meets threshold', () => {
+    const playerData = {
+      name: 'Jaxon Smith-Njigba',
+      team: 'SEA',
+      receiving_epa_rank: 3,
+      targets: 120,
+    }
+    const opponentData = {
+      team: 'SF',
+      epa_allowed_to_wr_rank: 8,
+    }
+    const context = {
+      dataTimestamp: Date.now(),
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkEpaThresholds(playerData, opponentData, context)
+
+    expect(findings.length).toBeGreaterThan(0)
+    expect(findings[0].agent).toBe('epa')
+    expect(findings[0].type).toBe('receiving_epa_mismatch')
+  })
+
+  it('returns empty when thresholds not met', () => {
+    const playerData = {
+      name: 'Random Player',
+      team: 'NYG',
+      receiving_epa_rank: 45,
+      targets: 30,
+    }
+    const opponentData = {
+      team: 'DAL',
+      epa_allowed_to_wr_rank: 25,
+    }
+    const context = {
+      dataTimestamp: Date.now(),
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkEpaThresholds(playerData, opponentData, context)
+
+    expect(findings.length).toBe(0)
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run __tests__/terminal/agents/epa.test.ts`
+Expected: FAIL (module not found)
+
+**Step 3: Create EPA thresholds module**
+
+```typescript
+// lib/terminal/agents/epa/thresholds.ts
+import type { Finding, AgentType } from '../../schemas'
+
+export const EPA_THRESHOLDS = {
+  receivingEpaRank: 10,     // top 10
+  epaAllowedRank: 10,       // opponent allows top 10
+  rushingEpaDiff: 0.15,
+  redZoneEpaDiff: 0.20,
+  minTargets: 50,           // sample size threshold
+} as const
+
+interface PlayerData {
+  name: string
+  team: string
+  receiving_epa_rank?: number
+  rushing_epa_rank?: number
+  receiving_epa?: number
+  rushing_epa?: number
+  targets?: number
+  rushes?: number
+}
+
+interface OpponentData {
+  team: string
+  epa_allowed_to_wr_rank?: number
+  epa_allowed_to_rb_rank?: number
+  receiving_epa_allowed?: number
+  rushing_epa_allowed?: number
+}
+
+interface ThresholdContext {
+  dataTimestamp: number
+  dataVersion: string
+}
+
+export function checkEpaThresholds(
+  player: PlayerData,
+  opponent: OpponentData,
+  context: ThresholdContext
+): Finding[] {
+  const findings: Finding[] = []
+  const agent: AgentType = 'epa'
+
+  // Check receiving EPA mismatch
+  if (
+    player.receiving_epa_rank !== undefined &&
+    player.receiving_epa_rank <= EPA_THRESHOLDS.receivingEpaRank &&
+    opponent.epa_allowed_to_wr_rank !== undefined &&
+    opponent.epa_allowed_to_wr_rank <= EPA_THRESHOLDS.epaAllowedRank &&
+    (player.targets ?? 0) >= EPA_THRESHOLDS.minTargets
+  ) {
+    findings.push({
+      id: `epa-${player.name.toLowerCase().replace(/\s+/g, '-')}-recv-${Date.now()}`,
+      agent,
+      type: 'receiving_epa_mismatch',
+      stat: 'receiving_epa_rank',
+      value_num: player.receiving_epa_rank,
+      value_type: 'numeric',
+      threshold_met: `rank <= ${EPA_THRESHOLDS.receivingEpaRank} AND opponent allows top ${EPA_THRESHOLDS.epaAllowedRank}`,
+      comparison_context: `${ordinal(player.receiving_epa_rank)} in league vs ${ordinal(opponent.epa_allowed_to_wr_rank)} worst defense`,
+      source_ref: `local://data/epa/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  // Check rushing EPA mismatch
+  if (
+    player.rushing_epa_rank !== undefined &&
+    player.rushing_epa_rank <= EPA_THRESHOLDS.receivingEpaRank &&
+    opponent.epa_allowed_to_rb_rank !== undefined &&
+    opponent.epa_allowed_to_rb_rank <= EPA_THRESHOLDS.epaAllowedRank &&
+    (player.rushes ?? 0) >= EPA_THRESHOLDS.minTargets
+  ) {
+    findings.push({
+      id: `epa-${player.name.toLowerCase().replace(/\s+/g, '-')}-rush-${Date.now()}`,
+      agent,
+      type: 'rushing_epa_mismatch',
+      stat: 'rushing_epa_rank',
+      value_num: player.rushing_epa_rank,
+      value_type: 'numeric',
+      threshold_met: `rank <= ${EPA_THRESHOLDS.receivingEpaRank} AND opponent allows top ${EPA_THRESHOLDS.epaAllowedRank}`,
+      comparison_context: `${ordinal(player.rushing_epa_rank)} in league vs ${ordinal(opponent.epa_allowed_to_rb_rank)} worst defense`,
+      source_ref: `local://data/epa/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  return findings
+}
+
+function ordinal(n: number): string {
+  const s = ['th', 'st', 'nd', 'rd']
+  const v = n % 100
+  return n + (s[(v - 20) % 10] || s[v] || s[0])
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm test -- --run __tests__/terminal/agents/epa.test.ts`
+Expected: PASS
+
+**Step 5: Create EPA skill.md**
+
+```markdown
+// lib/terminal/agents/epa/skill.md
+# EPA Agent
+
+## Domain
+Expected Points Added - measures efficiency beyond yards/TDs.
+Focus on receiving EPA, rushing EPA, and EPA allowed by position.
+
+## Metrics That Matter
+- receiving_epa
+- rushing_epa
+- red_zone_epa
+- epa_allowed (by position)
+
+## Voice Notes
+Speak in efficiency terms. Avoid "he's been hot" - say "0.31 EPA/target, 3rd in league."
+Always tie to a specific betting implication.
+
+## Suppress If
+- Sample size < 50 targets/rushes
+- Backup QB situation
+- Player injury status questionable or worse
+
+## Example Claims
+- "Receiving EPA + Target Share ranks top 5 in league vs opponent average"
+- "Rushing EPA differential exceeds 0.15 vs league average"
+```
+
+**Step 6: Commit**
+
+```bash
+git add lib/terminal/agents/epa/ __tests__/terminal/agents/epa.test.ts
+git commit -m "feat(terminal): add EPA agent thresholds and skill definition"
+```
+
+---
+
+## Task 7: Pressure Agent Thresholds
+
+**Files:**
+- Create: `lib/terminal/agents/pressure/thresholds.ts`
+- Create: `lib/terminal/agents/pressure/skill.md`
+- Test: `__tests__/terminal/agents/pressure.test.ts`
+
+**Step 1: Write failing test**
+
+```typescript
+// __tests__/terminal/agents/pressure.test.ts
+import { describe, it, expect } from 'vitest'
+import { PRESSURE_THRESHOLDS, checkPressureThresholds } from '@/lib/terminal/agents/pressure/thresholds'
+
+describe('PRESSURE_THRESHOLDS', () => {
+  it('has defined threshold values', () => {
+    expect(PRESSURE_THRESHOLDS.pressureRateRank).toBe(10)
+    expect(PRESSURE_THRESHOLDS.passBlockWinRateRank).toBe(22)
+  })
+})
+
+describe('checkPressureThresholds', () => {
+  it('returns finding when pressure mismatch exists', () => {
+    const defenseData = {
+      team: 'SF',
+      pressure_rate: 42,
+      pressure_rate_rank: 3,
+    }
+    const offenseData = {
+      team: 'SEA',
+      qb_name: 'Sam Darnold',
+      pass_block_win_rate_rank: 28,
+      qb_passer_rating_under_pressure: 31.2,
+    }
+    const context = {
+      dataTimestamp: Date.now(),
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkPressureThresholds(defenseData, offenseData, context)
+
+    expect(findings.length).toBeGreaterThan(0)
+    expect(findings[0].agent).toBe('pressure')
+    expect(findings[0].type).toBe('pressure_rate_advantage')
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run __tests__/terminal/agents/pressure.test.ts`
+Expected: FAIL (module not found)
+
+**Step 3: Create pressure thresholds module**
+
+```typescript
+// lib/terminal/agents/pressure/thresholds.ts
+import type { Finding, AgentType } from '../../schemas'
+
+export const PRESSURE_THRESHOLDS = {
+  pressureRateRank: 10,         // top 10 pass rush
+  passBlockWinRateRank: 22,     // bottom 10 OL
+  sackRateRank: 10,
+  qbPressuredRatingThreshold: 60,  // bad under pressure
+} as const
+
+interface DefenseData {
+  team: string
+  pressure_rate?: number
+  pressure_rate_rank?: number
+  sack_rate?: number
+  sack_rate_rank?: number
+}
+
+interface OffenseData {
+  team: string
+  qb_name: string
+  pass_block_win_rate_rank?: number
+  qb_passer_rating_under_pressure?: number
+}
+
+interface ThresholdContext {
+  dataTimestamp: number
+  dataVersion: string
+}
+
+export function checkPressureThresholds(
+  defense: DefenseData,
+  offense: OffenseData,
+  context: ThresholdContext
+): Finding[] {
+  const findings: Finding[] = []
+  const agent: AgentType = 'pressure'
+
+  // Check pressure rate advantage
+  if (
+    defense.pressure_rate_rank !== undefined &&
+    defense.pressure_rate_rank <= PRESSURE_THRESHOLDS.pressureRateRank &&
+    offense.pass_block_win_rate_rank !== undefined &&
+    offense.pass_block_win_rate_rank >= PRESSURE_THRESHOLDS.passBlockWinRateRank
+  ) {
+    findings.push({
+      id: `pressure-${defense.team.toLowerCase()}-vs-${offense.team.toLowerCase()}-${Date.now()}`,
+      agent,
+      type: 'pressure_rate_advantage',
+      stat: 'pressure_rate_rank',
+      value_num: defense.pressure_rate_rank,
+      value_type: 'numeric',
+      threshold_met: `defense rank <= ${PRESSURE_THRESHOLDS.pressureRateRank} AND OL rank >= ${PRESSURE_THRESHOLDS.passBlockWinRateRank}`,
+      comparison_context: `${ordinal(defense.pressure_rate_rank)} pass rush vs ${ordinal(offense.pass_block_win_rate_rank)} OL`,
+      source_ref: `local://data/pressure/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+
+    // Add QB vulnerability if data exists
+    if (
+      offense.qb_passer_rating_under_pressure !== undefined &&
+      offense.qb_passer_rating_under_pressure < PRESSURE_THRESHOLDS.qbPressuredRatingThreshold
+    ) {
+      findings.push({
+        id: `pressure-${offense.qb_name.toLowerCase().replace(/\s+/g, '-')}-vuln-${Date.now()}`,
+        agent,
+        type: 'qb_pressure_vulnerability',
+        stat: 'qb_passer_rating_under_pressure',
+        value_num: offense.qb_passer_rating_under_pressure,
+        value_type: 'numeric',
+        threshold_met: `passer rating under pressure < ${PRESSURE_THRESHOLDS.qbPressuredRatingThreshold}`,
+        comparison_context: `${offense.qb_name}: ${offense.qb_passer_rating_under_pressure} rating when pressured`,
+        source_ref: `local://data/pressure/${context.dataVersion}.json`,
+        source_type: 'local',
+        source_timestamp: context.dataTimestamp,
+      })
+    }
+  }
+
+  return findings
+}
+
+function ordinal(n: number): string {
+  const s = ['th', 'st', 'nd', 'rd']
+  const v = n % 100
+  return n + (s[(v - 20) % 10] || s[v] || s[0])
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm test -- --run __tests__/terminal/agents/pressure.test.ts`
+Expected: PASS
+
+**Step 5: Create pressure skill.md**
+
+```markdown
+// lib/terminal/agents/pressure/skill.md
+# Pressure Agent
+
+## Domain
+Pass rush efficiency and offensive line protection.
+Focus on pressure rate, sack rate, and QB performance under duress.
+
+## Metrics That Matter
+- pressure_rate
+- pass_block_win_rate
+- sack_rate
+- qb_passer_rating_under_pressure
+
+## Voice Notes
+Speak in matchup terms. "42% pressure rate meets 28th-ranked OL" not "they get after the QB."
+Always quantify the mismatch.
+
+## Suppress If
+- Defense missing key pass rusher
+- OL has significant injury upgrade (starter returning)
+- Weather heavily favors run game
+
+## Example Claims
+- "Pressure Rate ranks top 3 in league vs bottom 10 pass protection"
+- "QB passer rating under pressure trails league average by 30+ points"
+```
+
+**Step 6: Commit**
+
+```bash
+git add lib/terminal/agents/pressure/ __tests__/terminal/agents/pressure.test.ts
+git commit -m "feat(terminal): add Pressure agent thresholds and skill definition"
+```
+
+---
+
+## Task 8: Weather Agent Thresholds
+
+**Files:**
+- Create: `lib/terminal/agents/weather/thresholds.ts`
+- Create: `lib/terminal/agents/weather/skill.md`
+- Test: `__tests__/terminal/agents/weather.test.ts`
+
+**Step 1: Write failing test**
+
+```typescript
+// __tests__/terminal/agents/weather.test.ts
+import { describe, it, expect } from 'vitest'
+import { WEATHER_THRESHOLDS, checkWeatherThresholds } from '@/lib/terminal/agents/weather/thresholds'
+
+describe('checkWeatherThresholds', () => {
+  it('returns finding for high wind', () => {
+    const weather = {
+      temperature: 45,
+      wind_mph: 18,
+      precipitation_chance: 10,
+      indoor: false,
+    }
+    const context = {
+      dataTimestamp: Date.now(),
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkWeatherThresholds(weather, context)
+
+    expect(findings.length).toBeGreaterThan(0)
+    expect(findings[0].type).toBe('weather_wind')
+  })
+
+  it('returns empty for indoor games', () => {
+    const weather = {
+      temperature: 72,
+      wind_mph: 0,
+      precipitation_chance: 0,
+      indoor: true,
+    }
+    const context = {
+      dataTimestamp: Date.now(),
+      dataVersion: '2025-week-20',
+    }
+
+    const findings = checkWeatherThresholds(weather, context)
+
+    expect(findings.length).toBe(0)
+  })
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run __tests__/terminal/agents/weather.test.ts`
+Expected: FAIL (module not found)
+
+**Step 3: Create weather thresholds module**
+
+```typescript
+// lib/terminal/agents/weather/thresholds.ts
+import type { Finding, AgentType } from '../../schemas'
+
+export const WEATHER_THRESHOLDS = {
+  windMph: 15,              // wind becomes factor
+  coldTemp: 32,             // freezing affects play
+  hotTemp: 90,              // heat affects play
+  precipitationChance: 50,  // likely rain/snow
+} as const
+
+interface WeatherData {
+  temperature: number
+  wind_mph: number
+  precipitation_chance: number
+  precipitation_type?: 'rain' | 'snow' | 'none'
+  indoor: boolean
+  stadium?: string
+}
+
+interface ThresholdContext {
+  dataTimestamp: number
+  dataVersion: string
+}
+
+export function checkWeatherThresholds(
+  weather: WeatherData,
+  context: ThresholdContext
+): Finding[] {
+  const findings: Finding[] = []
+  const agent: AgentType = 'weather'
+
+  // Indoor games - no weather impact
+  if (weather.indoor) {
+    return findings
+  }
+
+  // Check wind
+  if (weather.wind_mph >= WEATHER_THRESHOLDS.windMph) {
+    findings.push({
+      id: `weather-wind-${Date.now()}`,
+      agent,
+      type: 'weather_wind',
+      stat: 'wind_mph',
+      value_num: weather.wind_mph,
+      value_type: 'numeric',
+      threshold_met: `wind >= ${WEATHER_THRESHOLDS.windMph} mph`,
+      comparison_context: `${weather.wind_mph} mph wind - affects deep passing`,
+      source_ref: `local://data/weather/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  // Check cold
+  if (weather.temperature <= WEATHER_THRESHOLDS.coldTemp) {
+    findings.push({
+      id: `weather-cold-${Date.now()}`,
+      agent,
+      type: 'weather_cold',
+      stat: 'temperature',
+      value_num: weather.temperature,
+      value_type: 'numeric',
+      threshold_met: `temp <= ${WEATHER_THRESHOLDS.coldTemp}°F`,
+      comparison_context: `${weather.temperature}°F - cold weather game`,
+      source_ref: `local://data/weather/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  // Check precipitation
+  if (weather.precipitation_chance >= WEATHER_THRESHOLDS.precipitationChance) {
+    findings.push({
+      id: `weather-precip-${Date.now()}`,
+      agent,
+      type: 'weather_rain',
+      stat: 'precipitation_chance',
+      value_num: weather.precipitation_chance,
+      value_type: 'numeric',
+      threshold_met: `precipitation >= ${WEATHER_THRESHOLDS.precipitationChance}%`,
+      comparison_context: `${weather.precipitation_chance}% chance of ${weather.precipitation_type || 'precipitation'}`,
+      source_ref: `local://data/weather/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  return findings
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm test -- --run __tests__/terminal/agents/weather.test.ts`
+Expected: PASS
+
+**Step 5: Create weather skill.md and commit**
+
+```markdown
+// lib/terminal/agents/weather/skill.md
+# Weather Agent
+
+## Domain
+Environmental factors affecting game play.
+Focus on wind, temperature, and precipitation.
+
+## Metrics That Matter
+- wind_mph
+- temperature
+- precipitation_chance
+
+## Voice Notes
+Be specific about impact. "18 mph crosswind limits deep accuracy" not "bad weather."
+Note stadium orientation if relevant.
+
+## Suppress If
+- Indoor stadium
+- Dome closed
+- Marginal conditions (12 mph wind, 40°F)
+
+## Example Claims
+- "Wind exceeds 15 mph threshold - impacts deep passing game"
+- "Temperature trails 32°F - cold weather adjustments likely"
+```
+
+**Step 6: Commit**
+
+```bash
+git add lib/terminal/agents/weather/ __tests__/terminal/agents/weather.test.ts
+git commit -m "feat(terminal): add Weather agent thresholds and skill definition"
+```
+
+---
+
+## Task 9: Remaining Agents (QB, HB, WR, TE)
+
+Create similar threshold modules for QB, HB, WR, TE agents following the same pattern.
+
+**Files per agent:**
+- `lib/terminal/agents/{agent}/thresholds.ts`
+- `lib/terminal/agents/{agent}/skill.md`
+- `__tests__/terminal/agents/{agent}.test.ts`
+
+**Commit after each agent:**
+```bash
+git commit -m "feat(terminal): add {Agent} agent thresholds and skill definition"
+```
+
+---
+
+## Task 10: Agent Engine - Finding Aggregator
+
+**Files:**
+- Create: `lib/terminal/engine/agent-runner.ts`
+- Create: `lib/terminal/engine/index.ts`
+- Test: `__tests__/terminal/engine/agent-runner.test.ts`
+
+**Step 1: Write failing test**
+
+```typescript
+// __tests__/terminal/engine/agent-runner.test.ts
+import { describe, it, expect } from 'vitest'
+import { runAgents } from '@/lib/terminal/engine/agent-runner'
+
+describe('runAgents', () => {
+  it('aggregates findings from all agents', async () => {
+    const matchupContext = {
+      homeTeam: 'SEA',
+      awayTeam: 'SF',
+      players: {
+        'SEA': [{ name: 'Jaxon Smith-Njigba', receiving_epa_rank: 3, targets: 120 }],
+        'SF': [{ name: 'Christian McCaffrey', rushing_epa_rank: 2, rushes: 200 }],
+      },
+      teamStats: {
+        'SEA': { epa_allowed_to_wr_rank: 15, pass_block_win_rate_rank: 28 },
+        'SF': { pressure_rate_rank: 3, epa_allowed_to_rb_rank: 20 },
+      },
+      weather: { temperature: 38, wind_mph: 12, precipitation_chance: 10, indoor: false },
+      dataTimestamp: Date.now(),
+      dataVersion: '2025-week-20',
+    }
+
+    const result = await runAgents(matchupContext)
+
+    expect(result.findings).toBeInstanceOf(Array)
+    expect(result.agentsInvoked).toContain('epa')
+    expect(result.agentsInvoked).toContain('pressure')
+    expect(result.agentsInvoked).toContain('weather')
+  })
+})
+```
+
+**Step 2: Implement agent runner (abbreviated - follow TDD pattern)**
+
+```typescript
+// lib/terminal/engine/agent-runner.ts
+import type { Finding, AgentType } from '../schemas'
+import { checkEpaThresholds } from '../agents/epa/thresholds'
+import { checkPressureThresholds } from '../agents/pressure/thresholds'
+import { checkWeatherThresholds } from '../agents/weather/thresholds'
+
+const ALL_AGENTS: AgentType[] = ['epa', 'pressure', 'weather', 'qb', 'hb', 'wr', 'te']
+
+interface MatchupContext {
+  homeTeam: string
+  awayTeam: string
+  players: Record<string, any[]>
+  teamStats: Record<string, any>
+  weather: any
+  dataTimestamp: number
+  dataVersion: string
+}
+
+interface AgentRunResult {
+  findings: Finding[]
+  agentsInvoked: AgentType[]
+  agentsSilent: AgentType[]
+}
+
+export async function runAgents(context: MatchupContext): Promise<AgentRunResult> {
+  const findings: Finding[] = []
+  const agentsInvoked: AgentType[] = []
+  const agentsSilent: AgentType[] = []
+
+  const thresholdContext = {
+    dataTimestamp: context.dataTimestamp,
+    dataVersion: context.dataVersion,
+  }
+
+  // Run EPA agent
+  for (const team of [context.homeTeam, context.awayTeam]) {
+    const opponent = team === context.homeTeam ? context.awayTeam : context.homeTeam
+    for (const player of context.players[team] || []) {
+      const epaFindings = checkEpaThresholds(player, context.teamStats[opponent], thresholdContext)
+      findings.push(...epaFindings)
+    }
+  }
+  if (findings.some(f => f.agent === 'epa')) {
+    agentsInvoked.push('epa')
+  } else {
+    agentsSilent.push('epa')
+  }
+
+  // Run Pressure agent
+  const pressureFindings = checkPressureThresholds(
+    context.teamStats[context.awayTeam],
+    { ...context.teamStats[context.homeTeam], team: context.homeTeam, qb_name: 'QB' },
+    thresholdContext
+  )
+  findings.push(...pressureFindings)
+  if (pressureFindings.length > 0) {
+    agentsInvoked.push('pressure')
+  } else {
+    agentsSilent.push('pressure')
+  }
+
+  // Run Weather agent
+  const weatherFindings = checkWeatherThresholds(context.weather, thresholdContext)
+  findings.push(...weatherFindings)
+  if (weatherFindings.length > 0) {
+    agentsInvoked.push('weather')
+  } else {
+    agentsSilent.push('weather')
+  }
+
+  // Add remaining agents to silent if not invoked
+  for (const agent of ALL_AGENTS) {
+    if (!agentsInvoked.includes(agent) && !agentsSilent.includes(agent)) {
+      agentsSilent.push(agent)
+    }
+  }
+
+  return { findings, agentsInvoked, agentsSilent }
+}
+```
+
+**Step 3: Commit**
+
+```bash
+git add lib/terminal/engine/ __tests__/terminal/engine/
+git commit -m "feat(terminal): add agent runner to aggregate findings"
+```
+
+---
+
+## Task 11: /api/scan Route
+
+**Files:**
+- Create: `app/api/terminal/scan/route.ts`
+- Test: Manual verification
+
+**Step 1: Create the scan route**
+
+```typescript
+// app/api/terminal/scan/route.ts
+import { NextRequest } from 'next/server'
+import { randomUUID } from 'crypto'
+import { z } from 'zod'
+import { runAgents } from '@/lib/terminal/engine/agent-runner'
+import { buildProvenance, hashContent } from '@/lib/terminal/engine/provenance'
+import { renderFindingsFallback, formatFallbackForTerminal } from '@/lib/terminal/engine/fallback-renderer'
+import { checkRequestLimits, REQUEST_LIMITS } from '@/lib/terminal/engine/guardrails'
+
+const ScanRequestSchema = z.object({
+  matchup: z.string(),  // "49ers @ Seahawks" or "SF @ SEA"
+})
+
+export async function POST(req: NextRequest) {
+  const requestId = randomUUID()
+
+  try {
+    const body = await req.json()
+    const parsed = ScanRequestSchema.safeParse(body)
+
+    if (!parsed.success) {
+      return Response.json(
+        { error: 'Invalid request', details: parsed.error.flatten() },
+        { status: 400 }
+      )
+    }
+
+    // TODO: Load matchup context from data layer
+    const matchupContext = await loadMatchupContext(parsed.data.matchup)
+
+    // Run threshold checks (deterministic)
+    const { findings, agentsInvoked, agentsSilent } = await runAgents(matchupContext)
+
+    if (findings.length === 0) {
+      return Response.json({
+        request_id: requestId,
+        alerts: [],
+        message: 'No significant findings for this matchup',
+        agents_silent: agentsSilent,
+      })
+    }
+
+    // TODO: Transform Finding[] → Alert[] via LLM
+    // For now, return findings with fallback renderer
+    const fallbackOutput = renderFindingsFallback(findings)
+
+    const provenance = buildProvenance({
+      requestId,
+      prompt: '', // No LLM call yet
+      skillMds: {},
+      findings,
+      dataVersion: matchupContext.dataVersion,
+      dataTimestamp: matchupContext.dataTimestamp,
+      searchTimestamps: [],
+      agentsInvoked,
+      agentsSilent,
+      cacheHits: 0,
+      cacheMisses: 0,
+      llmModel: 'none',
+      llmTemperature: 0,
+    })
+
+    return Response.json({
+      request_id: requestId,
+      findings,
+      fallback_output: fallbackOutput,
+      provenance,
+    })
+  } catch (error) {
+    return Response.json(
+      { error: 'Scan failed', message: (error as Error).message },
+      { status: 500 }
+    )
+  }
+}
+
+async function loadMatchupContext(matchup: string) {
+  // TODO: Implement actual data loading
+  // For now, return mock data
+  return {
+    homeTeam: 'SEA',
+    awayTeam: 'SF',
+    players: {},
+    teamStats: {},
+    weather: { temperature: 45, wind_mph: 10, precipitation_chance: 20, indoor: false },
+    dataTimestamp: Date.now(),
+    dataVersion: '2025-week-20',
+  }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add app/api/terminal/scan/
+git commit -m "feat(terminal): add /api/terminal/scan route with Finding[] output"
+```
+
+---
+
+## Task 12-15: Continue with remaining routes and UI
+
+Following the same TDD pattern:
+
+- **Task 12:** LLM analyst integration (Finding[] → Alert[])
+- **Task 13:** /api/terminal/build route (Alert[] → Script[])
+- **Task 14:** /api/terminal/bet route (Alert[] → Ladder[])
+- **Task 15:** Terminal UI component with command parser
+- **Task 16:** Team color theming
+
+Each task follows the same structure:
+1. Write failing test
+2. Verify it fails
+3. Implement minimally
+4. Verify it passes
+5. Commit
+
+---
+
+## Summary
+
+This plan covers the full implementation in order:
+
+1. **Schemas** - Zod contracts for Evidence, Finding, Alert, ClaimParts, Provenance
+2. **Validators** - Source integrity, implications allowlist, line freshness, edge language
+3. **Confidence** - Code-derived calculation
+4. **Provenance** - Hashing for reproducibility
+5. **Guardrails** - Request limits, streaming heartbeat, fallback renderer
+6. **Agents** - EPA, Pressure, Weather, QB, HB, WR, TE thresholds
+7. **Engine** - Agent runner aggregating findings
+8. **Routes** - /api/scan, /api/build, /api/bet
+9. **UI** - Terminal emulator with command parser and team theming

--- a/lib/terminal/agents/epa/skill.md
+++ b/lib/terminal/agents/epa/skill.md
@@ -1,0 +1,24 @@
+# EPA Agent
+
+## Domain
+Expected Points Added - measures efficiency beyond yards/TDs.
+Focus on receiving EPA, rushing EPA, and EPA allowed by position.
+
+## Metrics That Matter
+- receiving_epa
+- rushing_epa
+- red_zone_epa
+- epa_allowed (by position)
+
+## Voice Notes
+Speak in efficiency terms. Avoid "he's been hot" - say "0.31 EPA/target, 3rd in league."
+Always tie to a specific betting implication.
+
+## Suppress If
+- Sample size < 50 targets/rushes
+- Backup QB situation
+- Player injury status questionable or worse
+
+## Example Claims
+- "Receiving EPA + Target Share ranks top 5 in league vs opponent average"
+- "Rushing EPA differential exceeds 0.15 vs league average"

--- a/lib/terminal/agents/epa/thresholds.ts
+++ b/lib/terminal/agents/epa/thresholds.ts
@@ -1,0 +1,96 @@
+import type { Finding, AgentType } from '../../schemas'
+
+export const EPA_THRESHOLDS = {
+  receivingEpaRank: 10,     // top 10
+  epaAllowedRank: 10,       // opponent allows top 10
+  rushingEpaDiff: 0.15,
+  redZoneEpaDiff: 0.20,
+  minTargets: 50,           // sample size threshold
+} as const
+
+interface PlayerData {
+  name: string
+  team: string
+  receiving_epa_rank?: number
+  rushing_epa_rank?: number
+  receiving_epa?: number
+  rushing_epa?: number
+  targets?: number
+  rushes?: number
+}
+
+interface OpponentData {
+  team: string
+  epa_allowed_to_wr_rank?: number
+  epa_allowed_to_rb_rank?: number
+  receiving_epa_allowed?: number
+  rushing_epa_allowed?: number
+}
+
+interface ThresholdContext {
+  dataTimestamp: number
+  dataVersion: string
+}
+
+export function checkEpaThresholds(
+  player: PlayerData,
+  opponent: OpponentData,
+  context: ThresholdContext
+): Finding[] {
+  const findings: Finding[] = []
+  const agent: AgentType = 'epa'
+
+  // Check receiving EPA mismatch
+  if (
+    player.receiving_epa_rank !== undefined &&
+    player.receiving_epa_rank <= EPA_THRESHOLDS.receivingEpaRank &&
+    opponent.epa_allowed_to_wr_rank !== undefined &&
+    opponent.epa_allowed_to_wr_rank <= EPA_THRESHOLDS.epaAllowedRank &&
+    (player.targets ?? 0) >= EPA_THRESHOLDS.minTargets
+  ) {
+    findings.push({
+      id: `epa-${player.name.toLowerCase().replace(/\s+/g, '-')}-recv-${context.dataTimestamp}`,
+      agent,
+      type: 'receiving_epa_mismatch',
+      stat: 'receiving_epa_rank',
+      value_num: player.receiving_epa_rank,
+      value_type: 'numeric',
+      threshold_met: `rank <= ${EPA_THRESHOLDS.receivingEpaRank} AND opponent allows top ${EPA_THRESHOLDS.epaAllowedRank}`,
+      comparison_context: `${ordinal(player.receiving_epa_rank)} in league vs ${ordinal(opponent.epa_allowed_to_wr_rank)} worst defense`,
+      source_ref: `local://data/epa/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  // Check rushing EPA mismatch
+  if (
+    player.rushing_epa_rank !== undefined &&
+    player.rushing_epa_rank <= EPA_THRESHOLDS.receivingEpaRank &&
+    opponent.epa_allowed_to_rb_rank !== undefined &&
+    opponent.epa_allowed_to_rb_rank <= EPA_THRESHOLDS.epaAllowedRank &&
+    (player.rushes ?? 0) >= EPA_THRESHOLDS.minTargets
+  ) {
+    findings.push({
+      id: `epa-${player.name.toLowerCase().replace(/\s+/g, '-')}-rush-${context.dataTimestamp}`,
+      agent,
+      type: 'rushing_epa_mismatch',
+      stat: 'rushing_epa_rank',
+      value_num: player.rushing_epa_rank,
+      value_type: 'numeric',
+      threshold_met: `rank <= ${EPA_THRESHOLDS.receivingEpaRank} AND opponent allows top ${EPA_THRESHOLDS.epaAllowedRank}`,
+      comparison_context: `${ordinal(player.rushing_epa_rank)} in league vs ${ordinal(opponent.epa_allowed_to_rb_rank)} worst defense`,
+      source_ref: `local://data/epa/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  return findings
+}
+
+function ordinal(n: number): string {
+  const s = ['th', 'st', 'nd', 'rd']
+  const v = n % 100
+  return n + (s[(v - 20) % 10] || s[v] || s[0])
+}

--- a/lib/terminal/agents/hb/skill.md
+++ b/lib/terminal/agents/hb/skill.md
@@ -1,0 +1,26 @@
+# HB Agent
+
+## Domain
+Halfback/Running back rushing performance and dual-threat capability.
+Focus on volume, efficiency, and touchdown scoring.
+
+## Metrics That Matter
+- rush_yards
+- yards_per_carry
+- rush_tds
+- receptions (dual-threat)
+- red_zone_touches
+
+## Voice Notes
+Quantify workload and efficiency. "185 carries, 4.8 YPC, 8th in league" not "workhorse back."
+Note game script implications (pace, lead/deficit tendencies).
+
+## Suppress If
+- Sample size < 80 carries
+- Sharing backfield significantly
+- Coming off injury
+
+## Example Claims
+- "Rush yards rank top 5 vs bottom 10 rush defense"
+- "YPC exceeds 5.0 vs defense allowing top 5 YPC"
+- "Receiving rank top 10 among RBs - dual threat value"

--- a/lib/terminal/agents/hb/thresholds.ts
+++ b/lib/terminal/agents/hb/thresholds.ts
@@ -1,0 +1,142 @@
+import type { Finding, AgentType } from '../../schemas'
+
+export const HB_THRESHOLDS = {
+  rushYardsRank: 10,          // top 10 rushing yards
+  yardsPerCarryRank: 10,      // top 10 YPC
+  touchdownsRank: 10,         // top 10 rushing TDs
+  defenseRushRank: 22,        // bottom 10 rush defense (vulnerable)
+  yardsAllowedRank: 22,       // bottom 10 yards allowed
+  minCarries: 80,             // sample size
+  receptionRank: 15,          // top 15 receiving backs
+} as const
+
+interface HBData {
+  name: string
+  team: string
+  rush_yards?: number
+  rush_yards_rank?: number
+  yards_per_carry?: number
+  yards_per_carry_rank?: number
+  rush_tds?: number
+  rush_td_rank?: number
+  carries?: number
+  receptions?: number
+  reception_rank?: number
+}
+
+interface OpponentDefenseData {
+  team: string
+  rush_defense_rank?: number
+  rush_yards_allowed_rank?: number
+  rush_td_allowed_rank?: number
+}
+
+interface ThresholdContext {
+  dataTimestamp: number
+  dataVersion: string
+}
+
+export function checkHbThresholds(
+  hb: HBData,
+  defense: OpponentDefenseData,
+  context: ThresholdContext
+): Finding[] {
+  const findings: Finding[] = []
+  const agent: AgentType = 'hb'
+
+  // Check rushing volume vs vulnerable defense
+  if (
+    hb.rush_yards_rank !== undefined &&
+    hb.rush_yards_rank <= HB_THRESHOLDS.rushYardsRank &&
+    defense.rush_defense_rank !== undefined &&
+    defense.rush_defense_rank >= HB_THRESHOLDS.defenseRushRank &&
+    (hb.carries ?? 0) >= HB_THRESHOLDS.minCarries
+  ) {
+    findings.push({
+      id: `hb-${hb.name.toLowerCase().replace(/\s+/g, '-')}-volume-${context.dataTimestamp}`,
+      agent,
+      type: 'hb_volume_advantage',
+      stat: 'rush_yards_rank',
+      value_num: hb.rush_yards_rank,
+      value_type: 'numeric',
+      threshold_met: `rush yards rank <= ${HB_THRESHOLDS.rushYardsRank} AND defense rank >= ${HB_THRESHOLDS.defenseRushRank}`,
+      comparison_context: `${hb.name}: ${ordinal(hb.rush_yards_rank)} rush yards vs ${ordinal(defense.rush_defense_rank)} rush defense`,
+      source_ref: `local://data/hb/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  // Check efficiency (YPC) vs poor rush defense
+  if (
+    hb.yards_per_carry_rank !== undefined &&
+    hb.yards_per_carry_rank <= HB_THRESHOLDS.yardsPerCarryRank &&
+    defense.rush_yards_allowed_rank !== undefined &&
+    defense.rush_yards_allowed_rank >= HB_THRESHOLDS.yardsAllowedRank &&
+    (hb.carries ?? 0) >= HB_THRESHOLDS.minCarries
+  ) {
+    findings.push({
+      id: `hb-${hb.name.toLowerCase().replace(/\s+/g, '-')}-efficiency-${context.dataTimestamp}`,
+      agent,
+      type: 'hb_efficiency_advantage',
+      stat: 'yards_per_carry_rank',
+      value_num: hb.yards_per_carry_rank,
+      value_type: 'numeric',
+      threshold_met: `YPC rank <= ${HB_THRESHOLDS.yardsPerCarryRank} AND defense yards rank >= ${HB_THRESHOLDS.yardsAllowedRank}`,
+      comparison_context: `${hb.name}: ${ordinal(hb.yards_per_carry_rank)} YPC vs ${ordinal(defense.rush_yards_allowed_rank)} yards allowed`,
+      source_ref: `local://data/hb/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  // Check TD scoring opportunity
+  if (
+    hb.rush_td_rank !== undefined &&
+    hb.rush_td_rank <= HB_THRESHOLDS.touchdownsRank &&
+    defense.rush_td_allowed_rank !== undefined &&
+    defense.rush_td_allowed_rank >= HB_THRESHOLDS.defenseRushRank
+  ) {
+    findings.push({
+      id: `hb-${hb.name.toLowerCase().replace(/\s+/g, '-')}-td-${context.dataTimestamp}`,
+      agent,
+      type: 'hb_td_opportunity',
+      stat: 'rush_td_rank',
+      value_num: hb.rush_td_rank,
+      value_type: 'numeric',
+      threshold_met: `TD rank <= ${HB_THRESHOLDS.touchdownsRank} AND defense TD allowed rank >= ${HB_THRESHOLDS.defenseRushRank}`,
+      comparison_context: `${hb.name}: ${ordinal(hb.rush_td_rank)} rush TDs vs ${ordinal(defense.rush_td_allowed_rank)} TD allowed`,
+      source_ref: `local://data/hb/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  // Check receiving back opportunity
+  if (
+    hb.reception_rank !== undefined &&
+    hb.reception_rank <= HB_THRESHOLDS.receptionRank
+  ) {
+    findings.push({
+      id: `hb-${hb.name.toLowerCase().replace(/\s+/g, '-')}-receiving-${context.dataTimestamp}`,
+      agent,
+      type: 'hb_receiving_factor',
+      stat: 'reception_rank',
+      value_num: hb.reception_rank,
+      value_type: 'numeric',
+      threshold_met: `reception rank <= ${HB_THRESHOLDS.receptionRank}`,
+      comparison_context: `${hb.name}: ${ordinal(hb.reception_rank)} in RB receptions - dual threat`,
+      source_ref: `local://data/hb/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  return findings
+}
+
+function ordinal(n: number): string {
+  const s = ['th', 'st', 'nd', 'rd']
+  const v = n % 100
+  return n + (s[(v - 20) % 10] || s[v] || s[0])
+}

--- a/lib/terminal/agents/pressure/skill.md
+++ b/lib/terminal/agents/pressure/skill.md
@@ -1,0 +1,24 @@
+# Pressure Agent
+
+## Domain
+Pass rush efficiency and offensive line protection.
+Focus on pressure rate, sack rate, and QB performance under duress.
+
+## Metrics That Matter
+- pressure_rate
+- pass_block_win_rate
+- sack_rate
+- qb_passer_rating_under_pressure
+
+## Voice Notes
+Speak in matchup terms. "42% pressure rate meets 28th-ranked OL" not "they get after the QB."
+Always quantify the mismatch.
+
+## Suppress If
+- Defense missing key pass rusher
+- OL has significant injury upgrade (starter returning)
+- Weather heavily favors run game
+
+## Example Claims
+- "Pressure Rate ranks top 3 in league vs bottom 10 pass protection"
+- "QB passer rating under pressure trails league average by 30+ points"

--- a/lib/terminal/agents/pressure/thresholds.ts
+++ b/lib/terminal/agents/pressure/thresholds.ts
@@ -1,0 +1,87 @@
+import type { Finding, AgentType } from '../../schemas'
+
+export const PRESSURE_THRESHOLDS = {
+  pressureRateRank: 10,         // top 10 pass rush
+  passBlockWinRateRank: 22,     // bottom 10 OL
+  sackRateRank: 10,
+  qbPressuredRatingThreshold: 60,  // bad under pressure
+} as const
+
+interface DefenseData {
+  team: string
+  pressure_rate?: number
+  pressure_rate_rank?: number
+  sack_rate?: number
+  sack_rate_rank?: number
+}
+
+interface OffenseData {
+  team: string
+  qb_name: string
+  pass_block_win_rate_rank?: number
+  qb_passer_rating_under_pressure?: number
+}
+
+interface ThresholdContext {
+  dataTimestamp: number
+  dataVersion: string
+}
+
+export function checkPressureThresholds(
+  defense: DefenseData,
+  offense: OffenseData,
+  context: ThresholdContext
+): Finding[] {
+  const findings: Finding[] = []
+  const agent: AgentType = 'pressure'
+
+  // Check pressure rate advantage
+  if (
+    defense.pressure_rate_rank !== undefined &&
+    defense.pressure_rate_rank <= PRESSURE_THRESHOLDS.pressureRateRank &&
+    offense.pass_block_win_rate_rank !== undefined &&
+    offense.pass_block_win_rate_rank >= PRESSURE_THRESHOLDS.passBlockWinRateRank
+  ) {
+    findings.push({
+      id: `pressure-${defense.team.toLowerCase()}-vs-${offense.team.toLowerCase()}-${context.dataTimestamp}`,
+      agent,
+      type: 'pressure_rate_advantage',
+      stat: 'pressure_rate_rank',
+      value_num: defense.pressure_rate_rank,
+      value_type: 'numeric',
+      threshold_met: `defense rank <= ${PRESSURE_THRESHOLDS.pressureRateRank} AND OL rank >= ${PRESSURE_THRESHOLDS.passBlockWinRateRank}`,
+      comparison_context: `${ordinal(defense.pressure_rate_rank)} pass rush vs ${ordinal(offense.pass_block_win_rate_rank)} OL`,
+      source_ref: `local://data/pressure/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+
+    // Add QB vulnerability if data exists
+    if (
+      offense.qb_passer_rating_under_pressure !== undefined &&
+      offense.qb_passer_rating_under_pressure < PRESSURE_THRESHOLDS.qbPressuredRatingThreshold
+    ) {
+      findings.push({
+        id: `pressure-${offense.qb_name.toLowerCase().replace(/\s+/g, '-')}-vuln-${context.dataTimestamp}`,
+        agent,
+        type: 'qb_pressure_vulnerability',
+        stat: 'qb_passer_rating_under_pressure',
+        value_num: offense.qb_passer_rating_under_pressure,
+        value_type: 'numeric',
+        threshold_met: `passer rating under pressure < ${PRESSURE_THRESHOLDS.qbPressuredRatingThreshold}`,
+        comparison_context: `${offense.qb_name}: ${offense.qb_passer_rating_under_pressure} rating when pressured`,
+        source_ref: `local://data/pressure/${context.dataVersion}.json`,
+        source_type: 'local',
+        source_timestamp: context.dataTimestamp,
+      })
+    }
+  }
+
+  return findings
+}
+
+function ordinal(n: number): string {
+  const s = ['th', 'st', 'nd', 'rd']
+  const v = n % 100
+  return n + (s[(v - 20) % 10] || s[v] || s[0])
+}

--- a/lib/terminal/agents/qb/skill.md
+++ b/lib/terminal/agents/qb/skill.md
@@ -1,0 +1,26 @@
+# QB Agent
+
+## Domain
+Quarterback performance metrics and passing game efficiency.
+Focus on QB rating, yards per attempt, and turnover tendencies.
+
+## Metrics That Matter
+- qb_rating
+- completion_pct
+- yards_per_attempt
+- turnover_pct
+- pressure_rating
+
+## Voice Notes
+Quantify efficiency precisely. "106.4 passer rating, 4th in league" not "playing great."
+Always pair with opposing defense rank.
+
+## Suppress If
+- Sample size < 150 attempts
+- First game in new system
+- Starting debut
+
+## Example Claims
+- "QB Rating ranks top 5 vs bottom 10 pass defense"
+- "YPA exceeds 8.0 vs defense allowing top 5 YPA"
+- "Turnover rate concern vs top 3 INT defense"

--- a/lib/terminal/agents/qb/thresholds.ts
+++ b/lib/terminal/agents/qb/thresholds.ts
@@ -1,0 +1,122 @@
+import type { Finding, AgentType } from '../../schemas'
+
+export const QB_THRESHOLDS = {
+  qbRatingRank: 10,           // top 10 QB rating
+  completionPctRank: 10,      // top 10 completion %
+  yardsPerAttemptRank: 10,    // top 10 YPA
+  turnoverPctRank: 22,        // bottom 10 turnover rate (bad)
+  defensePassRank: 22,        // bottom 10 pass defense (vulnerable)
+  minAttempts: 150,           // sample size
+} as const
+
+interface QBData {
+  name: string
+  team: string
+  qb_rating?: number
+  qb_rating_rank?: number
+  completion_pct?: number
+  completion_pct_rank?: number
+  yards_per_attempt?: number
+  yards_per_attempt_rank?: number
+  turnover_pct?: number
+  turnover_pct_rank?: number
+  attempts?: number
+}
+
+interface OpponentDefenseData {
+  team: string
+  pass_defense_rank?: number
+  pass_yards_allowed_rank?: number
+  pass_td_allowed_rank?: number
+  interception_rate_rank?: number
+}
+
+interface ThresholdContext {
+  dataTimestamp: number
+  dataVersion: string
+}
+
+export function checkQbThresholds(
+  qb: QBData,
+  defense: OpponentDefenseData,
+  context: ThresholdContext
+): Finding[] {
+  const findings: Finding[] = []
+  const agent: AgentType = 'qb'
+
+  // Check QB rating vs vulnerable pass defense
+  if (
+    qb.qb_rating_rank !== undefined &&
+    qb.qb_rating_rank <= QB_THRESHOLDS.qbRatingRank &&
+    defense.pass_defense_rank !== undefined &&
+    defense.pass_defense_rank >= QB_THRESHOLDS.defensePassRank &&
+    (qb.attempts ?? 0) >= QB_THRESHOLDS.minAttempts
+  ) {
+    findings.push({
+      id: `qb-${qb.name.toLowerCase().replace(/\s+/g, '-')}-rating-${context.dataTimestamp}`,
+      agent,
+      type: 'qb_rating_advantage',
+      stat: 'qb_rating_rank',
+      value_num: qb.qb_rating_rank,
+      value_type: 'numeric',
+      threshold_met: `QB rating rank <= ${QB_THRESHOLDS.qbRatingRank} AND defense rank >= ${QB_THRESHOLDS.defensePassRank}`,
+      comparison_context: `${qb.name}: ${ordinal(qb.qb_rating_rank)} QB rating vs ${ordinal(defense.pass_defense_rank)} pass defense`,
+      source_ref: `local://data/qb/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  // Check YPA advantage
+  if (
+    qb.yards_per_attempt_rank !== undefined &&
+    qb.yards_per_attempt_rank <= QB_THRESHOLDS.yardsPerAttemptRank &&
+    defense.pass_yards_allowed_rank !== undefined &&
+    defense.pass_yards_allowed_rank >= QB_THRESHOLDS.defensePassRank &&
+    (qb.attempts ?? 0) >= QB_THRESHOLDS.minAttempts
+  ) {
+    findings.push({
+      id: `qb-${qb.name.toLowerCase().replace(/\s+/g, '-')}-ypa-${context.dataTimestamp}`,
+      agent,
+      type: 'qb_ypa_advantage',
+      stat: 'yards_per_attempt_rank',
+      value_num: qb.yards_per_attempt_rank,
+      value_type: 'numeric',
+      threshold_met: `YPA rank <= ${QB_THRESHOLDS.yardsPerAttemptRank} AND defense yards rank >= ${QB_THRESHOLDS.defensePassRank}`,
+      comparison_context: `${qb.name}: ${ordinal(qb.yards_per_attempt_rank)} YPA vs ${ordinal(defense.pass_yards_allowed_rank)} yards allowed`,
+      source_ref: `local://data/qb/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  // Check turnover-prone QB vs ball-hawking defense
+  if (
+    qb.turnover_pct_rank !== undefined &&
+    qb.turnover_pct_rank >= QB_THRESHOLDS.turnoverPctRank &&
+    defense.interception_rate_rank !== undefined &&
+    defense.interception_rate_rank <= 10 // Top 10 INT rate
+  ) {
+    findings.push({
+      id: `qb-${qb.name.toLowerCase().replace(/\s+/g, '-')}-turnover-${context.dataTimestamp}`,
+      agent,
+      type: 'qb_turnover_risk',
+      stat: 'turnover_pct_rank',
+      value_num: qb.turnover_pct_rank,
+      value_type: 'numeric',
+      threshold_met: `QB turnover rank >= ${QB_THRESHOLDS.turnoverPctRank} AND defense INT rank <= 10`,
+      comparison_context: `${qb.name}: ${ordinal(qb.turnover_pct_rank)} turnover rate vs ${ordinal(defense.interception_rate_rank)} INT rate`,
+      source_ref: `local://data/qb/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  return findings
+}
+
+function ordinal(n: number): string {
+  const s = ['th', 'st', 'nd', 'rd']
+  const v = n % 100
+  return n + (s[(v - 20) % 10] || s[v] || s[0])
+}

--- a/lib/terminal/agents/te/skill.md
+++ b/lib/terminal/agents/te/skill.md
@@ -1,0 +1,26 @@
+# TE Agent
+
+## Domain
+Tight end target volume, efficiency, and red zone opportunities.
+Focus on target share among TEs, receiving production, and scoring chances.
+
+## Metrics That Matter
+- target_share (among TEs)
+- receiving_yards
+- receiving_tds
+- red_zone_targets
+- seam_route_targets
+
+## Voice Notes
+Quantify the TE-specific matchup. "Top 3 TE vs defense allowing most yards to TEs" not "good matchup."
+Note if TE lines up in slot or inline (affects coverage type).
+
+## Suppress If
+- Sample size < 40 targets
+- Primarily blocking role
+- Secondary TE when starter healthy
+
+## Example Claims
+- "Target share ranks top 5 among TEs vs bottom 10 TE defense"
+- "Red zone targets rank top 3 among TEs - high TD probability"
+- "Defense allows 3rd most yards to TEs - matchup advantage"

--- a/lib/terminal/agents/te/thresholds.ts
+++ b/lib/terminal/agents/te/thresholds.ts
@@ -1,0 +1,141 @@
+import type { Finding, AgentType } from '../../schemas'
+
+export const TE_THRESHOLDS = {
+  targetShareRank: 8,         // top 8 for TE (smaller pool)
+  receivingYardsRank: 8,      // top 8 receiving yards
+  receivingTdRank: 8,         // top 8 receiving TDs
+  defenseTeRank: 22,          // bottom 10 TE defense (vulnerable)
+  redZoneTargetRank: 8,       // top 8 red zone targets
+  minTargets: 40,             // sample size (lower for TE)
+} as const
+
+interface TEData {
+  name: string
+  team: string
+  targets?: number
+  target_share?: number
+  target_share_rank?: number
+  receiving_yards?: number
+  receiving_yards_rank?: number
+  receiving_tds?: number
+  receiving_td_rank?: number
+  red_zone_targets?: number
+  red_zone_target_rank?: number
+}
+
+interface OpponentDefenseData {
+  team: string
+  te_defense_rank?: number
+  yards_allowed_to_te_rank?: number
+  td_allowed_to_te_rank?: number
+}
+
+interface ThresholdContext {
+  dataTimestamp: number
+  dataVersion: string
+}
+
+export function checkTeThresholds(
+  te: TEData,
+  defense: OpponentDefenseData,
+  context: ThresholdContext
+): Finding[] {
+  const findings: Finding[] = []
+  const agent: AgentType = 'te'
+
+  // Check target share vs vulnerable TE defense
+  if (
+    te.target_share_rank !== undefined &&
+    te.target_share_rank <= TE_THRESHOLDS.targetShareRank &&
+    defense.te_defense_rank !== undefined &&
+    defense.te_defense_rank >= TE_THRESHOLDS.defenseTeRank &&
+    (te.targets ?? 0) >= TE_THRESHOLDS.minTargets
+  ) {
+    findings.push({
+      id: `te-${te.name.toLowerCase().replace(/\s+/g, '-')}-volume-${context.dataTimestamp}`,
+      agent,
+      type: 'te_target_volume',
+      stat: 'target_share_rank',
+      value_num: te.target_share_rank,
+      value_type: 'numeric',
+      threshold_met: `target share rank <= ${TE_THRESHOLDS.targetShareRank} AND defense rank >= ${TE_THRESHOLDS.defenseTeRank}`,
+      comparison_context: `${te.name}: ${ordinal(te.target_share_rank)} target share vs ${ordinal(defense.te_defense_rank)} TE defense`,
+      source_ref: `local://data/te/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  // Check receiving yards vs defense allowing yards to TE
+  if (
+    te.receiving_yards_rank !== undefined &&
+    te.receiving_yards_rank <= TE_THRESHOLDS.receivingYardsRank &&
+    defense.yards_allowed_to_te_rank !== undefined &&
+    defense.yards_allowed_to_te_rank >= TE_THRESHOLDS.defenseTeRank &&
+    (te.targets ?? 0) >= TE_THRESHOLDS.minTargets
+  ) {
+    findings.push({
+      id: `te-${te.name.toLowerCase().replace(/\s+/g, '-')}-yards-${context.dataTimestamp}`,
+      agent,
+      type: 'te_yardage_advantage',
+      stat: 'receiving_yards_rank',
+      value_num: te.receiving_yards_rank,
+      value_type: 'numeric',
+      threshold_met: `receiving yards rank <= ${TE_THRESHOLDS.receivingYardsRank} AND defense yards rank >= ${TE_THRESHOLDS.defenseTeRank}`,
+      comparison_context: `${te.name}: ${ordinal(te.receiving_yards_rank)} TE receiving yards vs ${ordinal(defense.yards_allowed_to_te_rank)} yards allowed`,
+      source_ref: `local://data/te/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  // Check TD opportunity
+  if (
+    te.receiving_td_rank !== undefined &&
+    te.receiving_td_rank <= TE_THRESHOLDS.receivingTdRank &&
+    defense.td_allowed_to_te_rank !== undefined &&
+    defense.td_allowed_to_te_rank >= TE_THRESHOLDS.defenseTeRank
+  ) {
+    findings.push({
+      id: `te-${te.name.toLowerCase().replace(/\s+/g, '-')}-td-${context.dataTimestamp}`,
+      agent,
+      type: 'te_td_opportunity',
+      stat: 'receiving_td_rank',
+      value_num: te.receiving_td_rank,
+      value_type: 'numeric',
+      threshold_met: `TD rank <= ${TE_THRESHOLDS.receivingTdRank} AND defense TD allowed rank >= ${TE_THRESHOLDS.defenseTeRank}`,
+      comparison_context: `${te.name}: ${ordinal(te.receiving_td_rank)} TE TDs vs ${ordinal(defense.td_allowed_to_te_rank)} TD allowed to TE`,
+      source_ref: `local://data/te/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  // Check red zone factor
+  if (
+    te.red_zone_target_rank !== undefined &&
+    te.red_zone_target_rank <= TE_THRESHOLDS.redZoneTargetRank
+  ) {
+    findings.push({
+      id: `te-${te.name.toLowerCase().replace(/\s+/g, '-')}-rz-${context.dataTimestamp}`,
+      agent,
+      type: 'te_red_zone_factor',
+      stat: 'red_zone_target_rank',
+      value_num: te.red_zone_target_rank,
+      value_type: 'numeric',
+      threshold_met: `red zone target rank <= ${TE_THRESHOLDS.redZoneTargetRank}`,
+      comparison_context: `${te.name}: ${ordinal(te.red_zone_target_rank)} red zone TE targets - high TD upside`,
+      source_ref: `local://data/te/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  return findings
+}
+
+function ordinal(n: number): string {
+  const s = ['th', 'st', 'nd', 'rd']
+  const v = n % 100
+  return n + (s[(v - 20) % 10] || s[v] || s[0])
+}

--- a/lib/terminal/agents/weather/skill.md
+++ b/lib/terminal/agents/weather/skill.md
@@ -1,0 +1,23 @@
+# Weather Agent
+
+## Domain
+Environmental factors affecting game play.
+Focus on wind, temperature, and precipitation.
+
+## Metrics That Matter
+- wind_mph
+- temperature
+- precipitation_chance
+
+## Voice Notes
+Be specific about impact. "18 mph crosswind limits deep accuracy" not "bad weather."
+Note stadium orientation if relevant.
+
+## Suppress If
+- Indoor stadium
+- Dome closed
+- Marginal conditions (12 mph wind, 40°F)
+
+## Example Claims
+- "Wind exceeds 15 mph threshold - impacts deep passing game"
+- "Temperature trails 32°F - cold weather adjustments likely"

--- a/lib/terminal/agents/weather/thresholds.ts
+++ b/lib/terminal/agents/weather/thresholds.ts
@@ -1,0 +1,88 @@
+import type { Finding, AgentType } from '../../schemas'
+
+export const WEATHER_THRESHOLDS = {
+  windMph: 15,              // wind becomes factor
+  coldTemp: 32,             // freezing affects play
+  hotTemp: 90,              // heat affects play
+  precipitationChance: 50,  // likely rain/snow
+} as const
+
+interface WeatherData {
+  temperature: number
+  wind_mph: number
+  precipitation_chance: number
+  precipitation_type?: 'rain' | 'snow' | 'none'
+  indoor: boolean
+  stadium?: string
+}
+
+interface ThresholdContext {
+  dataTimestamp: number
+  dataVersion: string
+}
+
+export function checkWeatherThresholds(
+  weather: WeatherData,
+  context: ThresholdContext
+): Finding[] {
+  const findings: Finding[] = []
+  const agent: AgentType = 'weather'
+
+  // Indoor games - no weather impact
+  if (weather.indoor) {
+    return findings
+  }
+
+  // Check wind
+  if (weather.wind_mph >= WEATHER_THRESHOLDS.windMph) {
+    findings.push({
+      id: `weather-wind-${context.dataTimestamp}`,
+      agent,
+      type: 'weather_wind',
+      stat: 'wind_mph',
+      value_num: weather.wind_mph,
+      value_type: 'numeric',
+      threshold_met: `wind >= ${WEATHER_THRESHOLDS.windMph} mph`,
+      comparison_context: `${weather.wind_mph} mph wind - affects deep passing`,
+      source_ref: `local://data/weather/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  // Check cold
+  if (weather.temperature <= WEATHER_THRESHOLDS.coldTemp) {
+    findings.push({
+      id: `weather-cold-${context.dataTimestamp}`,
+      agent,
+      type: 'weather_cold',
+      stat: 'temperature',
+      value_num: weather.temperature,
+      value_type: 'numeric',
+      threshold_met: `temp <= ${WEATHER_THRESHOLDS.coldTemp}°F`,
+      comparison_context: `${weather.temperature}°F - cold weather game`,
+      source_ref: `local://data/weather/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  // Check precipitation
+  if (weather.precipitation_chance >= WEATHER_THRESHOLDS.precipitationChance) {
+    findings.push({
+      id: `weather-precip-${context.dataTimestamp}`,
+      agent,
+      type: 'weather_rain',
+      stat: 'precipitation_chance',
+      value_num: weather.precipitation_chance,
+      value_type: 'numeric',
+      threshold_met: `precipitation >= ${WEATHER_THRESHOLDS.precipitationChance}%`,
+      comparison_context: `${weather.precipitation_chance}% chance of ${weather.precipitation_type || 'precipitation'}`,
+      source_ref: `local://data/weather/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  return findings
+}

--- a/lib/terminal/agents/wr/skill.md
+++ b/lib/terminal/agents/wr/skill.md
@@ -1,0 +1,27 @@
+# WR Agent
+
+## Domain
+Wide receiver target volume, efficiency, and scoring opportunities.
+Focus on target share, yards per reception, and red zone usage.
+
+## Metrics That Matter
+- target_share
+- receiving_yards
+- yards_per_reception
+- receiving_tds
+- separation
+- air_yards_share
+
+## Voice Notes
+Quantify opportunity and efficiency. "28% target share, 14.2 YPR" not "gets a lot of looks."
+Note corner matchup if available.
+
+## Suppress If
+- Sample size < 50 targets
+- Shadow coverage from elite corner
+- QB change mid-season
+
+## Example Claims
+- "Target share ranks top 5 vs bottom 10 pass defense"
+- "Separation rank top 3 - elite route running vs zone defense"
+- "Red zone target share exceeds 25% vs defense allowing high TD rate"

--- a/lib/terminal/agents/wr/thresholds.ts
+++ b/lib/terminal/agents/wr/thresholds.ts
@@ -1,0 +1,144 @@
+import type { Finding, AgentType } from '../../schemas'
+
+export const WR_THRESHOLDS = {
+  targetShareRank: 10,        // top 10 target share
+  receivingYardsRank: 10,     // top 10 receiving yards
+  yardsPerReceptionRank: 10,  // top 10 YPR
+  receivingTdRank: 10,        // top 10 receiving TDs
+  defensePassRank: 22,        // bottom 10 pass defense (vulnerable)
+  separationRank: 10,         // top 10 separation
+  minTargets: 50,             // sample size
+} as const
+
+interface WRData {
+  name: string
+  team: string
+  targets?: number
+  target_share?: number
+  target_share_rank?: number
+  receiving_yards?: number
+  receiving_yards_rank?: number
+  yards_per_reception?: number
+  yards_per_reception_rank?: number
+  receiving_tds?: number
+  receiving_td_rank?: number
+  separation?: number
+  separation_rank?: number
+}
+
+interface OpponentDefenseData {
+  team: string
+  pass_defense_rank?: number
+  yards_allowed_to_wr_rank?: number
+  td_allowed_to_wr_rank?: number
+}
+
+interface ThresholdContext {
+  dataTimestamp: number
+  dataVersion: string
+}
+
+export function checkWrThresholds(
+  wr: WRData,
+  defense: OpponentDefenseData,
+  context: ThresholdContext
+): Finding[] {
+  const findings: Finding[] = []
+  const agent: AgentType = 'wr'
+
+  // Check target share vs vulnerable defense
+  if (
+    wr.target_share_rank !== undefined &&
+    wr.target_share_rank <= WR_THRESHOLDS.targetShareRank &&
+    defense.pass_defense_rank !== undefined &&
+    defense.pass_defense_rank >= WR_THRESHOLDS.defensePassRank &&
+    (wr.targets ?? 0) >= WR_THRESHOLDS.minTargets
+  ) {
+    findings.push({
+      id: `wr-${wr.name.toLowerCase().replace(/\s+/g, '-')}-volume-${context.dataTimestamp}`,
+      agent,
+      type: 'wr_target_volume',
+      stat: 'target_share_rank',
+      value_num: wr.target_share_rank,
+      value_type: 'numeric',
+      threshold_met: `target share rank <= ${WR_THRESHOLDS.targetShareRank} AND defense rank >= ${WR_THRESHOLDS.defensePassRank}`,
+      comparison_context: `${wr.name}: ${ordinal(wr.target_share_rank)} target share vs ${ordinal(defense.pass_defense_rank)} pass defense`,
+      source_ref: `local://data/wr/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  // Check receiving yards vs defense allowing yards
+  if (
+    wr.receiving_yards_rank !== undefined &&
+    wr.receiving_yards_rank <= WR_THRESHOLDS.receivingYardsRank &&
+    defense.yards_allowed_to_wr_rank !== undefined &&
+    defense.yards_allowed_to_wr_rank >= WR_THRESHOLDS.defensePassRank &&
+    (wr.targets ?? 0) >= WR_THRESHOLDS.minTargets
+  ) {
+    findings.push({
+      id: `wr-${wr.name.toLowerCase().replace(/\s+/g, '-')}-yards-${context.dataTimestamp}`,
+      agent,
+      type: 'wr_yardage_advantage',
+      stat: 'receiving_yards_rank',
+      value_num: wr.receiving_yards_rank,
+      value_type: 'numeric',
+      threshold_met: `receiving yards rank <= ${WR_THRESHOLDS.receivingYardsRank} AND defense yards rank >= ${WR_THRESHOLDS.defensePassRank}`,
+      comparison_context: `${wr.name}: ${ordinal(wr.receiving_yards_rank)} receiving yards vs ${ordinal(defense.yards_allowed_to_wr_rank)} yards allowed`,
+      source_ref: `local://data/wr/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  // Check TD opportunity
+  if (
+    wr.receiving_td_rank !== undefined &&
+    wr.receiving_td_rank <= WR_THRESHOLDS.receivingTdRank &&
+    defense.td_allowed_to_wr_rank !== undefined &&
+    defense.td_allowed_to_wr_rank >= WR_THRESHOLDS.defensePassRank
+  ) {
+    findings.push({
+      id: `wr-${wr.name.toLowerCase().replace(/\s+/g, '-')}-td-${context.dataTimestamp}`,
+      agent,
+      type: 'wr_td_opportunity',
+      stat: 'receiving_td_rank',
+      value_num: wr.receiving_td_rank,
+      value_type: 'numeric',
+      threshold_met: `TD rank <= ${WR_THRESHOLDS.receivingTdRank} AND defense TD allowed rank >= ${WR_THRESHOLDS.defensePassRank}`,
+      comparison_context: `${wr.name}: ${ordinal(wr.receiving_td_rank)} receiving TDs vs ${ordinal(defense.td_allowed_to_wr_rank)} TD allowed to WR`,
+      source_ref: `local://data/wr/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  // Check separation (elite route runner)
+  if (
+    wr.separation_rank !== undefined &&
+    wr.separation_rank <= WR_THRESHOLDS.separationRank
+  ) {
+    findings.push({
+      id: `wr-${wr.name.toLowerCase().replace(/\s+/g, '-')}-sep-${context.dataTimestamp}`,
+      agent,
+      type: 'wr_separation_advantage',
+      stat: 'separation_rank',
+      value_num: wr.separation_rank,
+      value_type: 'numeric',
+      threshold_met: `separation rank <= ${WR_THRESHOLDS.separationRank}`,
+      comparison_context: `${wr.name}: ${ordinal(wr.separation_rank)} separation - elite route runner`,
+      source_ref: `local://data/wr/${context.dataVersion}.json`,
+      source_type: 'local',
+      source_timestamp: context.dataTimestamp,
+    })
+  }
+
+  return findings
+}
+
+function ordinal(n: number): string {
+  const s = ['th', 'st', 'nd', 'rd']
+  const v = n % 100
+  return n + (s[(v - 20) % 10] || s[v] || s[0])
+}

--- a/lib/terminal/analyst/index.ts
+++ b/lib/terminal/analyst/index.ts
@@ -5,6 +5,7 @@ import type {
   LLMOutput,
   LLMFindingOutput,
   ClaimParts,
+  AnyImplication,
 } from '../schemas'
 import {
   assembleAlerts,
@@ -217,13 +218,15 @@ export function parseLLMOutput(
     }
 
     // Build output entry with validated implications only
+    const validatedImplications = implications.filter(imp => {
+      const v = validateImplicationsForAgent(finding.agent, [imp])
+      return v.valid
+    }) as AnyImplication[]
+
     output[findingId] = {
       severity: severity as 'high' | 'medium',
       claim_parts: claimParts,
-      implications: implications.filter(imp => {
-        const v = validateImplicationsForAgent(finding.agent, [imp])
-        return v.valid
-      }),
+      implications: validatedImplications,
       suppressions: (entry.suppressions as string[]) || [],
     }
   }

--- a/lib/terminal/analyst/index.ts
+++ b/lib/terminal/analyst/index.ts
@@ -1,0 +1,330 @@
+import type {
+  Finding,
+  Alert,
+  AgentType,
+  LLMOutput,
+  LLMFindingOutput,
+  ClaimParts,
+} from '../schemas'
+import {
+  assembleAlerts,
+  buildCodeDerivedFields,
+} from '../schemas/alert'
+import { validateImplicationsForAgent } from '../schemas/implications'
+import { renderClaim } from '../schemas/claim'
+import { calculateFindingConfidence } from '../engine/confidence'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+/**
+ * LLM Analyst
+ *
+ * Transforms Finding[] → Alert[] using an LLM.
+ * The LLM output is constrained to a keyed map by finding_id,
+ * and code-derived fields (id, agent, confidence, evidence) are preserved.
+ */
+
+// Skill MD paths
+const SKILL_MD_DIR = join(process.cwd(), 'lib/terminal/agents')
+
+/**
+ * Load skill.md for an agent
+ */
+export function loadSkillMd(agent: AgentType): string {
+  try {
+    const path = join(SKILL_MD_DIR, agent, 'skill.md')
+    return readFileSync(path, 'utf-8')
+  } catch {
+    return `# ${agent.toUpperCase()} Agent\n\nNo skill file available.`
+  }
+}
+
+/**
+ * Load all relevant skill.md files for findings
+ */
+export function loadRelevantSkillMds(
+  findings: Finding[]
+): Partial<Record<AgentType, string>> {
+  const agents = new Set(findings.map(f => f.agent))
+  const skillMds: Partial<Record<AgentType, string>> = {}
+
+  for (const agent of agents) {
+    skillMds[agent] = loadSkillMd(agent)
+  }
+
+  return skillMds
+}
+
+/**
+ * Build the prompt for the LLM analyst
+ */
+export function buildAnalystPrompt(
+  findings: Finding[],
+  skillMds: Partial<Record<AgentType, string>>
+): string {
+  const skillSections = Object.entries(skillMds)
+    .map(([agent, content]) => `## ${agent.toUpperCase()} Agent Skill\n\n${content}`)
+    .join('\n\n---\n\n')
+
+  const findingsJson = JSON.stringify(findings, null, 2)
+
+  return `You are a sports betting analyst terminal. Your job is to transform raw statistical findings into actionable alerts.
+
+## Your Skills
+
+${skillSections}
+
+---
+
+## Findings to Analyze
+
+${findingsJson}
+
+---
+
+## Output Format
+
+For EACH finding, provide a JSON object keyed by the finding's \`id\`. Each entry must follow this exact schema:
+
+\`\`\`json
+{
+  "finding_id_here": {
+    "severity": "high" | "medium",
+    "claim_parts": {
+      "metrics": ["receiving_epa", "target_share"],
+      "direction": "positive" | "negative" | "neutral",
+      "comparator": "ranks" | "exceeds" | "trails" | "matches" | "diverges_from",
+      "rank_or_percentile": {
+        "type": "rank" | "percentile",
+        "value": 5,
+        "scope": "league" | "position" | "conference" | "division",
+        "direction": "top" | "bottom"
+      },
+      "comparison_target": "league_average" | "opponent_average" | "position_average" | "season_baseline" | "historical_self",
+      "context_qualifier": "in_division" | "at_home" | "as_underdog" | "in_primetime" | "vs_top_10_defense" | "with_current_qb"
+    },
+    "implications": ["wr_yards_over", "te_receptions_over"],
+    "suppressions": []
+  }
+}
+\`\`\`
+
+## Valid Metrics
+receiving_epa, rushing_epa, pass_block_win_rate, pressure_rate, target_share, snap_count, red_zone_epa, epa_allowed, completion_rate, yards_per_attempt, sack_rate, passer_rating, yards_after_contact, separation, contested_catch_rate, route_participation, red_zone_targets
+
+## Valid Implications by Agent
+- EPA: wr_receptions_over/under, wr_yards_over/under, rb_yards_over/under, te_receptions_over, te_yards_over, team_total_over/under
+- PRESSURE: qb_sacks_over/under, qb_ints_over, qb_pass_yards_under, def_sacks_over
+- WEATHER: game_total_under, pass_yards_under, field_goals_over
+- QB: qb_pass_yards_over/under, qb_pass_tds_over/under, qb_completions_over/under, qb_ints_over
+- HB: rb_rush_yards_over/under, rb_receptions_over, rb_rush_attempts_over, rb_tds_over
+- WR: wr_receptions_over/under, wr_yards_over/under, wr_tds_over, wr_longest_reception_over
+- TE: te_receptions_over/under, te_yards_over/under, te_tds_over
+
+## Rules
+
+1. Use ONLY implications from each agent's valid list above
+2. severity: "high" for elite mismatch (top 5 vs bottom 5), "medium" for solid edge (top 10 vs bottom 10)
+3. metrics array must contain at least one valid metric
+4. rank_or_percentile is optional but useful for context
+5. comparison_target is optional
+6. context_qualifier is optional
+7. Do NOT hallucinate statistics - use only what's in the finding
+8. Output valid JSON only - no markdown, no explanation
+
+Respond with ONLY the JSON object, no surrounding text.`
+}
+
+/**
+ * Validate edge language in claim
+ */
+function validateEdgeLanguage(claim: string): { valid: boolean; violations: string[] } {
+  const EDGE_PATTERNS = [
+    /\bedge\b/i,
+    /\bvalue\b/i,
+    /\bmispriced\b/i,
+    /\bexploit\b/i,
+    /\bsharp\b/i,
+    /\block\b/i,
+  ]
+  const violations = EDGE_PATTERNS.filter(p => p.test(claim)).map(p => p.toString())
+  return { valid: violations.length === 0, violations }
+}
+
+/**
+ * Parse LLM output and validate against schemas
+ */
+export function parseLLMOutput(
+  raw: string,
+  findings: Finding[]
+): { output: LLMOutput; errors: string[] } {
+  const errors: string[] = []
+
+  // Parse JSON
+  let parsed: Record<string, unknown>
+  try {
+    // Strip markdown code blocks if present
+    const cleaned = raw.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim()
+    parsed = JSON.parse(cleaned)
+  } catch (e) {
+    return {
+      output: {},
+      errors: [`Failed to parse LLM output as JSON: ${(e as Error).message}`],
+    }
+  }
+
+  const output: LLMOutput = {}
+  const findingIds = new Set(findings.map(f => f.id))
+
+  for (const [findingId, value] of Object.entries(parsed)) {
+    // Validate finding_id exists
+    if (!findingIds.has(findingId)) {
+      errors.push(`Unknown finding_id: ${findingId}`)
+      continue
+    }
+
+    const finding = findings.find(f => f.id === findingId)!
+    const entry = value as Record<string, unknown>
+
+    // Validate severity
+    const severity = entry.severity as string
+    if (!['high', 'medium'].includes(severity)) {
+      errors.push(`Invalid severity for ${findingId}: ${severity}`)
+      continue
+    }
+
+    // Validate claim_parts
+    const claimParts = entry.claim_parts as ClaimParts | undefined
+    if (!claimParts || !claimParts.metrics || !Array.isArray(claimParts.metrics) || claimParts.metrics.length === 0) {
+      errors.push(`Missing or invalid claim_parts for ${findingId}`)
+      continue
+    }
+
+    // Validate implications against agent allowlist
+    const implications = (entry.implications as string[]) || []
+    const implValidation = validateImplicationsForAgent(finding.agent, implications)
+    if (!implValidation.valid) {
+      errors.push(`Invalid implications for ${findingId}: ${implValidation.invalid.join(', ')}`)
+    }
+
+    // Validate edge language in rendered claim
+    const renderedClaim = renderClaim(claimParts)
+    const edgeValidation = validateEdgeLanguage(renderedClaim)
+    if (!edgeValidation.valid) {
+      errors.push(
+        `Edge language detected in ${findingId}: ${edgeValidation.violations.join(', ')}`
+      )
+    }
+
+    // Build output entry with validated implications only
+    output[findingId] = {
+      severity: severity as 'high' | 'medium',
+      claim_parts: claimParts,
+      implications: implications.filter(imp => {
+        const v = validateImplicationsForAgent(finding.agent, [imp])
+        return v.valid
+      }),
+      suppressions: (entry.suppressions as string[]) || [],
+    }
+  }
+
+  return { output, errors }
+}
+
+/**
+ * Interface for LLM call
+ */
+export interface LLMCallOptions {
+  model?: string
+  temperature?: number
+  maxTokens?: number
+}
+
+/**
+ * Placeholder for actual LLM call
+ * This will be implemented with OpenAI SDK
+ */
+export async function callLLM(
+  prompt: string,
+  options: LLMCallOptions = {}
+): Promise<string> {
+  // TODO: Implement actual LLM call with OpenAI SDK
+  // For now, throw an error indicating not implemented
+  throw new Error('LLM integration not yet implemented. Use fallback mode.')
+}
+
+/**
+ * Full analyst pipeline: Finding[] → Alert[]
+ */
+export async function analyzeFindings(
+  findings: Finding[],
+  dataVersion: string,
+  options: LLMCallOptions = {}
+): Promise<{
+  alerts: Alert[]
+  llmOutput: LLMOutput
+  errors: string[]
+  skillMds: Partial<Record<AgentType, string>>
+  prompt: string
+}> {
+  if (findings.length === 0) {
+    return {
+      alerts: [],
+      llmOutput: {},
+      errors: [],
+      skillMds: {},
+      prompt: '',
+    }
+  }
+
+  // Load skill MDs
+  const skillMds = loadRelevantSkillMds(findings)
+
+  // Build prompt
+  const prompt = buildAnalystPrompt(findings, skillMds)
+
+  try {
+    // Call LLM
+    const raw = await callLLM(prompt, options)
+
+    // Parse and validate output
+    const { output, errors } = parseLLMOutput(raw, findings)
+
+    // Calculate confidences
+    const confidences = new Map<string, number>()
+    for (const finding of findings) {
+      confidences.set(finding.id, calculateFindingConfidence(finding))
+    }
+
+    // Filter to only non-suppressed findings
+    const filteredOutput: LLMOutput = {}
+    for (const [id, entry] of Object.entries(output)) {
+      if (entry.suppressions.length === 0) {
+        filteredOutput[id] = entry
+      }
+    }
+
+    // Filter findings to match
+    const filteredFindings = findings.filter(f => filteredOutput[f.id])
+
+    // Assemble alerts using schema function
+    const alerts = assembleAlerts(filteredFindings, filteredOutput, confidences, dataVersion)
+
+    return {
+      alerts,
+      llmOutput: output,
+      errors,
+      skillMds,
+      prompt,
+    }
+  } catch (error) {
+    // LLM call failed - return empty with error
+    return {
+      alerts: [],
+      llmOutput: {},
+      errors: [(error as Error).message],
+      skillMds,
+      prompt,
+    }
+  }
+}

--- a/lib/terminal/engine/agent-runner.ts
+++ b/lib/terminal/engine/agent-runner.ts
@@ -1,0 +1,313 @@
+import type { Finding, AgentType } from '../schemas'
+import { checkEpaThresholds } from '../agents/epa/thresholds'
+import { checkPressureThresholds } from '../agents/pressure/thresholds'
+import { checkWeatherThresholds } from '../agents/weather/thresholds'
+import { checkQbThresholds } from '../agents/qb/thresholds'
+import { checkHbThresholds } from '../agents/hb/thresholds'
+import { checkWrThresholds } from '../agents/wr/thresholds'
+import { checkTeThresholds } from '../agents/te/thresholds'
+
+/**
+ * Agent Runner
+ *
+ * Orchestrates all specialized agents and aggregates their findings.
+ * Each agent runs independently and produces Finding[] or stays silent.
+ */
+
+const ALL_AGENTS: AgentType[] = ['epa', 'pressure', 'weather', 'qb', 'hb', 'wr', 'te']
+
+interface PlayerData {
+  name: string
+  team: string
+  position: string
+  // EPA fields
+  receiving_epa_rank?: number
+  rushing_epa_rank?: number
+  targets?: number
+  rushes?: number
+  // QB fields
+  qb_rating_rank?: number
+  yards_per_attempt_rank?: number
+  turnover_pct_rank?: number
+  attempts?: number
+  // HB fields
+  rush_yards_rank?: number
+  yards_per_carry_rank?: number
+  rush_td_rank?: number
+  carries?: number
+  reception_rank?: number
+  // WR fields
+  target_share_rank?: number
+  receiving_yards_rank?: number
+  receiving_td_rank?: number
+  separation_rank?: number
+  // TE fields
+  red_zone_target_rank?: number
+}
+
+interface TeamStats {
+  // EPA defense
+  epa_allowed_to_wr_rank?: number
+  epa_allowed_to_rb_rank?: number
+  // Pressure
+  pressure_rate?: number
+  pressure_rate_rank?: number
+  pass_block_win_rate_rank?: number
+  qb_name?: string
+  qb_passer_rating_under_pressure?: number
+  // QB defense
+  pass_defense_rank?: number
+  pass_yards_allowed_rank?: number
+  interception_rate_rank?: number
+  // HB defense
+  rush_defense_rank?: number
+  rush_yards_allowed_rank?: number
+  rush_td_allowed_rank?: number
+  // WR defense
+  yards_allowed_to_wr_rank?: number
+  td_allowed_to_wr_rank?: number
+  // TE defense
+  te_defense_rank?: number
+  yards_allowed_to_te_rank?: number
+  td_allowed_to_te_rank?: number
+}
+
+interface WeatherData {
+  temperature: number
+  wind_mph: number
+  precipitation_chance: number
+  precipitation_type?: 'rain' | 'snow' | 'none'
+  indoor: boolean
+  stadium?: string
+}
+
+export interface MatchupContext {
+  homeTeam: string
+  awayTeam: string
+  players: Record<string, PlayerData[]>
+  teamStats: Record<string, TeamStats>
+  weather: WeatherData
+  dataTimestamp: number
+  dataVersion: string
+}
+
+export interface AgentRunResult {
+  findings: Finding[]
+  agentsInvoked: AgentType[]
+  agentsSilent: AgentType[]
+}
+
+/**
+ * Run all agents against the matchup context
+ */
+export async function runAgents(context: MatchupContext): Promise<AgentRunResult> {
+  const findings: Finding[] = []
+  const agentsWithFindings = new Set<AgentType>()
+
+  const thresholdContext = {
+    dataTimestamp: context.dataTimestamp,
+    dataVersion: context.dataVersion,
+  }
+
+  // Run EPA agent for all players
+  for (const team of [context.homeTeam, context.awayTeam]) {
+    const opponent = team === context.homeTeam ? context.awayTeam : context.homeTeam
+    const players = context.players[team] || []
+    const opponentStats = context.teamStats[opponent] || {}
+
+    for (const player of players) {
+      const epaFindings = checkEpaThresholds(
+        {
+          name: player.name,
+          team: player.team,
+          receiving_epa_rank: player.receiving_epa_rank,
+          rushing_epa_rank: player.rushing_epa_rank,
+          targets: player.targets,
+          rushes: player.rushes,
+        },
+        {
+          team: opponent,
+          epa_allowed_to_wr_rank: opponentStats.epa_allowed_to_wr_rank,
+          epa_allowed_to_rb_rank: opponentStats.epa_allowed_to_rb_rank,
+        },
+        thresholdContext
+      )
+      if (epaFindings.length > 0) {
+        findings.push(...epaFindings)
+        agentsWithFindings.add('epa')
+      }
+    }
+  }
+
+  // Run Pressure agent (team-level)
+  for (const team of [context.homeTeam, context.awayTeam]) {
+    const opponent = team === context.homeTeam ? context.awayTeam : context.homeTeam
+    const teamStats = context.teamStats[team] || {}
+    const opponentStats = context.teamStats[opponent] || {}
+
+    if (opponentStats.pressure_rate_rank !== undefined) {
+      const pressureFindings = checkPressureThresholds(
+        {
+          team: opponent,
+          pressure_rate: opponentStats.pressure_rate,
+          pressure_rate_rank: opponentStats.pressure_rate_rank,
+        },
+        {
+          team: team,
+          qb_name: teamStats.qb_name || 'Unknown QB',
+          pass_block_win_rate_rank: teamStats.pass_block_win_rate_rank,
+          qb_passer_rating_under_pressure: teamStats.qb_passer_rating_under_pressure,
+        },
+        thresholdContext
+      )
+      if (pressureFindings.length > 0) {
+        findings.push(...pressureFindings)
+        agentsWithFindings.add('pressure')
+      }
+    }
+  }
+
+  // Run Weather agent
+  const weatherFindings = checkWeatherThresholds(context.weather, thresholdContext)
+  if (weatherFindings.length > 0) {
+    findings.push(...weatherFindings)
+    agentsWithFindings.add('weather')
+  }
+
+  // Run QB agent
+  for (const team of [context.homeTeam, context.awayTeam]) {
+    const opponent = team === context.homeTeam ? context.awayTeam : context.homeTeam
+    const players = context.players[team] || []
+    const opponentStats = context.teamStats[opponent] || {}
+
+    for (const player of players.filter(p => p.position === 'QB')) {
+      const qbFindings = checkQbThresholds(
+        {
+          name: player.name,
+          team: player.team,
+          qb_rating_rank: player.qb_rating_rank,
+          yards_per_attempt_rank: player.yards_per_attempt_rank,
+          turnover_pct_rank: player.turnover_pct_rank,
+          attempts: player.attempts,
+        },
+        {
+          team: opponent,
+          pass_defense_rank: opponentStats.pass_defense_rank,
+          pass_yards_allowed_rank: opponentStats.pass_yards_allowed_rank,
+          interception_rate_rank: opponentStats.interception_rate_rank,
+        },
+        thresholdContext
+      )
+      if (qbFindings.length > 0) {
+        findings.push(...qbFindings)
+        agentsWithFindings.add('qb')
+      }
+    }
+  }
+
+  // Run HB agent
+  for (const team of [context.homeTeam, context.awayTeam]) {
+    const opponent = team === context.homeTeam ? context.awayTeam : context.homeTeam
+    const players = context.players[team] || []
+    const opponentStats = context.teamStats[opponent] || {}
+
+    for (const player of players.filter(p => p.position === 'HB' || p.position === 'RB')) {
+      const hbFindings = checkHbThresholds(
+        {
+          name: player.name,
+          team: player.team,
+          rush_yards_rank: player.rush_yards_rank,
+          yards_per_carry_rank: player.yards_per_carry_rank,
+          rush_td_rank: player.rush_td_rank,
+          reception_rank: player.reception_rank,
+          carries: player.carries,
+        },
+        {
+          team: opponent,
+          rush_defense_rank: opponentStats.rush_defense_rank,
+          rush_yards_allowed_rank: opponentStats.rush_yards_allowed_rank,
+          rush_td_allowed_rank: opponentStats.rush_td_allowed_rank,
+        },
+        thresholdContext
+      )
+      if (hbFindings.length > 0) {
+        findings.push(...hbFindings)
+        agentsWithFindings.add('hb')
+      }
+    }
+  }
+
+  // Run WR agent
+  for (const team of [context.homeTeam, context.awayTeam]) {
+    const opponent = team === context.homeTeam ? context.awayTeam : context.homeTeam
+    const players = context.players[team] || []
+    const opponentStats = context.teamStats[opponent] || {}
+
+    for (const player of players.filter(p => p.position === 'WR')) {
+      const wrFindings = checkWrThresholds(
+        {
+          name: player.name,
+          team: player.team,
+          target_share_rank: player.target_share_rank,
+          receiving_yards_rank: player.receiving_yards_rank,
+          receiving_td_rank: player.receiving_td_rank,
+          separation_rank: player.separation_rank,
+          targets: player.targets,
+        },
+        {
+          team: opponent,
+          pass_defense_rank: opponentStats.pass_defense_rank,
+          yards_allowed_to_wr_rank: opponentStats.yards_allowed_to_wr_rank,
+          td_allowed_to_wr_rank: opponentStats.td_allowed_to_wr_rank,
+        },
+        thresholdContext
+      )
+      if (wrFindings.length > 0) {
+        findings.push(...wrFindings)
+        agentsWithFindings.add('wr')
+      }
+    }
+  }
+
+  // Run TE agent
+  for (const team of [context.homeTeam, context.awayTeam]) {
+    const opponent = team === context.homeTeam ? context.awayTeam : context.homeTeam
+    const players = context.players[team] || []
+    const opponentStats = context.teamStats[opponent] || {}
+
+    for (const player of players.filter(p => p.position === 'TE')) {
+      const teFindings = checkTeThresholds(
+        {
+          name: player.name,
+          team: player.team,
+          target_share_rank: player.target_share_rank,
+          receiving_yards_rank: player.receiving_yards_rank,
+          receiving_td_rank: player.receiving_td_rank,
+          red_zone_target_rank: player.red_zone_target_rank,
+          targets: player.targets,
+        },
+        {
+          team: opponent,
+          te_defense_rank: opponentStats.te_defense_rank,
+          yards_allowed_to_te_rank: opponentStats.yards_allowed_to_te_rank,
+          td_allowed_to_te_rank: opponentStats.td_allowed_to_te_rank,
+        },
+        thresholdContext
+      )
+      if (teFindings.length > 0) {
+        findings.push(...teFindings)
+        agentsWithFindings.add('te')
+      }
+    }
+  }
+
+  // Calculate invoked vs silent
+  const agentsInvoked = ALL_AGENTS.filter(a => agentsWithFindings.has(a))
+  const agentsSilent = ALL_AGENTS.filter(a => !agentsWithFindings.has(a))
+
+  return {
+    findings,
+    agentsInvoked,
+    agentsSilent,
+  }
+}

--- a/lib/terminal/engine/confidence.ts
+++ b/lib/terminal/engine/confidence.ts
@@ -1,0 +1,133 @@
+import type { Finding, Evidence } from '../schemas'
+import { isLineEvidence } from '../schemas'
+
+/**
+ * Confidence Calculation
+ *
+ * Confidence is CODE-DERIVED, not LLM-derived.
+ * The LLM cannot modify confidence - it's calculated from:
+ * - Evidence count
+ * - Source quality (local vs web)
+ * - Data freshness
+ * - Sample size (if applicable)
+ * - Line freshness (if betting relevance claimed)
+ */
+
+export interface ConfidenceInputs {
+  evidenceCount: number
+  hasLocalSource: boolean
+  hasWebSource: boolean
+  webSourceAge: number | null       // ms since search
+  localDataAge: number              // ms since data_timestamp
+  sampleSize: number | null         // e.g. targets, snaps
+  hasLineEvidence: boolean
+  lineAge: number | null            // ms since line_timestamp
+}
+
+/**
+ * Calculate confidence score from inputs
+ * Returns value in [0, 1] range
+ */
+export function calculateConfidence(inputs: ConfidenceInputs): number {
+  let score = 0.5  // baseline
+
+  // Evidence quantity (+0.15 for 3+, +0.08 for 2)
+  if (inputs.evidenceCount >= 3) score += 0.15
+  else if (inputs.evidenceCount >= 2) score += 0.08
+
+  // Source quality
+  if (inputs.hasLocalSource) score += 0.10
+  if (inputs.hasWebSource && inputs.webSourceAge !== null && inputs.webSourceAge < 4 * 3600 * 1000) {
+    score += 0.08  // fresh web source (< 4 hours)
+  }
+
+  // Sample size (if applicable)
+  if (inputs.sampleSize !== null) {
+    if (inputs.sampleSize >= 100) score += 0.12
+    else if (inputs.sampleSize >= 50) score += 0.06
+    else score -= 0.10  // penalty for small sample
+  }
+
+  // Line freshness (if betting relevance claimed)
+  if (inputs.hasLineEvidence && inputs.lineAge !== null) {
+    if (inputs.lineAge < 30 * 60 * 1000) score += 0.10      // < 30 min
+    else if (inputs.lineAge < 2 * 3600 * 1000) score += 0.05 // < 2 hr
+    else score -= 0.15  // stale line penalty
+  }
+
+  // Data freshness penalty
+  if (inputs.localDataAge > 7 * 24 * 3600 * 1000) score -= 0.20  // > 7 days
+
+  // Clamp to [0, 1]
+  return Math.max(0, Math.min(1, score))
+}
+
+/**
+ * Build confidence inputs from a Finding
+ */
+export function confidenceInputsFromFinding(
+  finding: Finding,
+  additionalContext?: {
+    sampleSize?: number
+    lineTimestamp?: number
+  }
+): ConfidenceInputs {
+  const now = Date.now()
+
+  return {
+    evidenceCount: 1, // Single finding = 1 evidence piece
+    hasLocalSource: finding.source_type === 'local',
+    hasWebSource: finding.source_type === 'web',
+    webSourceAge: finding.source_type === 'web' ? now - finding.source_timestamp : null,
+    localDataAge: finding.source_type === 'local' ? now - finding.source_timestamp : 0,
+    sampleSize: additionalContext?.sampleSize ?? null,
+    hasLineEvidence: false, // Single finding doesn't have line evidence
+    lineAge: additionalContext?.lineTimestamp ? now - additionalContext.lineTimestamp : null,
+  }
+}
+
+/**
+ * Build confidence inputs from multiple evidence pieces
+ */
+export function confidenceInputsFromEvidence(
+  evidence: Evidence[],
+  dataTimestamp: number
+): ConfidenceInputs {
+  const now = Date.now()
+
+  const hasLocalSource = evidence.some(e => e.source_type === 'local')
+  const hasWebSource = evidence.some(e => e.source_type === 'web')
+  const hasLine = evidence.some(e => isLineEvidence(e))
+
+  // Get oldest web source age
+  const webSources = evidence.filter(e => e.source_type === 'web')
+  const webSourceAge = webSources.length > 0 ? now - dataTimestamp : null
+
+  // Get oldest line timestamp
+  const lineSources = evidence.filter(e => isLineEvidence(e))
+  const lineAge = lineSources.length > 0
+    ? now - Math.min(...lineSources.map(e => (e as any).line_timestamp))
+    : null
+
+  return {
+    evidenceCount: evidence.length,
+    hasLocalSource,
+    hasWebSource,
+    webSourceAge,
+    localDataAge: now - dataTimestamp,
+    sampleSize: null, // Would need to be passed separately
+    hasLineEvidence: hasLine,
+    lineAge,
+  }
+}
+
+/**
+ * Calculate confidence for a Finding
+ */
+export function calculateFindingConfidence(
+  finding: Finding,
+  additionalContext?: { sampleSize?: number }
+): number {
+  const inputs = confidenceInputsFromFinding(finding, additionalContext)
+  return calculateConfidence(inputs)
+}

--- a/lib/terminal/engine/fallback-renderer.ts
+++ b/lib/terminal/engine/fallback-renderer.ts
@@ -1,0 +1,112 @@
+import type { Finding, AgentType } from '../schemas'
+
+/**
+ * Fallback Renderer
+ *
+ * When the LLM analyst call fails, render findings directly
+ * so the terminal never hard-stalls.
+ */
+
+export interface FallbackLine {
+  agent: AgentType
+  line: string
+  source: string
+  severity: 'raw'
+}
+
+/**
+ * Render findings without LLM processing
+ */
+export function renderFindingsFallback(findings: Finding[]): FallbackLine[] {
+  return findings.map(f => ({
+    agent: f.agent,
+    line: `${f.stat}: ${f.value_num ?? f.value_str} (${f.comparison_context})`,
+    source: f.source_ref,
+    severity: 'raw' as const,
+  }))
+}
+
+/**
+ * Format fallback output for terminal display
+ */
+export function formatFallbackForTerminal(lines: FallbackLine[]): string {
+  const header = '\u26A0\uFE0F  Analyst offline. Raw findings:\n'
+
+  const body = lines
+    .map(
+      l =>
+        `   [${l.agent}] ${l.line}\n         \u2192 ${l.source}`
+    )
+    .join('\n\n')
+
+  const footer = '\n\n   Type "retry" or "build --raw" to continue with raw findings.'
+
+  return header + '\n' + body + footer
+}
+
+/**
+ * Agent display names
+ */
+const AGENT_DISPLAY: Record<AgentType, string> = {
+  epa: 'EPA Agent',
+  pressure: 'Pressure Agent',
+  weather: 'Weather Agent',
+  qb: 'QB Agent',
+  hb: 'HB Agent',
+  wr: 'WR Agent',
+  te: 'TE Agent',
+}
+
+/**
+ * Format raw findings for JSON API response
+ */
+export function formatFallbackForApi(findings: Finding[]): {
+  mode: 'fallback'
+  message: string
+  raw_findings: Array<{
+    id: string
+    agent: string
+    agent_display: string
+    stat: string
+    value: number | string | undefined
+    context: string
+    source: string
+  }>
+} {
+  return {
+    mode: 'fallback',
+    message: 'LLM analyst unavailable. Returning raw findings.',
+    raw_findings: findings.map(f => ({
+      id: f.id,
+      agent: f.agent,
+      agent_display: AGENT_DISPLAY[f.agent],
+      stat: f.stat,
+      value: f.value_num ?? f.value_str,
+      context: f.comparison_context,
+      source: f.source_ref,
+    })),
+  }
+}
+
+/**
+ * Determine if we should use fallback mode
+ */
+export function shouldUseFallback(error: unknown): boolean {
+  if (error instanceof Error) {
+    const msg = error.message.toLowerCase()
+    // Use fallback for LLM-related errors
+    if (
+      msg.includes('timeout') ||
+      msg.includes('rate limit') ||
+      msg.includes('context length') ||
+      msg.includes('api error') ||
+      msg.includes('network') ||
+      msg.includes('503') ||
+      msg.includes('502') ||
+      msg.includes('500')
+    ) {
+      return true
+    }
+  }
+  return false
+}

--- a/lib/terminal/engine/guardrails.ts
+++ b/lib/terminal/engine/guardrails.ts
@@ -1,0 +1,207 @@
+/**
+ * Guardrails & Streaming
+ *
+ * Operational safeguards:
+ * - Request token/cost limits
+ * - Streaming heartbeat
+ * - Fallback renderer (no LLM)
+ * - Web search budget/cache
+ */
+
+// Request limits
+export const REQUEST_LIMITS = {
+  maxInputTokens: 8000,
+  maxOutputTokens: 2000,
+  maxCostPerRequest: 0.15,  // $0.15 USD
+  timeoutMs: 45000,         // 45s
+} as const
+
+// Streaming config
+export const STREAM_CONFIG = {
+  heartbeatIntervalMs: 3000,
+  heartbeatPayload: { type: 'heartbeat' as const, status: 'processing' as const },
+} as const
+
+// Web search config
+export const SEARCH_CONFIG = {
+  enabled: true,            // kill-switch
+  budgetPerMatchup: 5,      // max searches per scan
+  budgetPerAgent: 2,        // max per agent per scan
+  cacheTTL: 3600 * 4,       // 4 hours
+  noiseThreshold: 0.3,      // if confidence < 0.3, don't use
+} as const
+
+export class GuardrailError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly details?: Record<string, unknown>
+  ) {
+    super(message)
+    this.name = 'GuardrailError'
+  }
+}
+
+interface RequestCheckInput {
+  inputTokens: number
+  estimatedCost?: number
+}
+
+/**
+ * Check request against limits
+ */
+export function checkRequestLimits(input: RequestCheckInput): void {
+  if (input.inputTokens > REQUEST_LIMITS.maxInputTokens) {
+    throw new GuardrailError(
+      'TOKEN_LIMIT_EXCEEDED',
+      `Input tokens (${input.inputTokens}) exceeds limit (${REQUEST_LIMITS.maxInputTokens})`,
+      { inputTokens: input.inputTokens, limit: REQUEST_LIMITS.maxInputTokens }
+    )
+  }
+
+  if (input.estimatedCost && input.estimatedCost > REQUEST_LIMITS.maxCostPerRequest) {
+    throw new GuardrailError(
+      'COST_LIMIT_EXCEEDED',
+      `Estimated cost ($${input.estimatedCost.toFixed(4)}) exceeds limit ($${REQUEST_LIMITS.maxCostPerRequest})`,
+      { estimatedCost: input.estimatedCost, limit: REQUEST_LIMITS.maxCostPerRequest }
+    )
+  }
+}
+
+/**
+ * Estimate token count (rough approximation)
+ */
+export function estimateTokens(text: string): number {
+  // Rough estimate: ~4 chars per token for English
+  return Math.ceil(text.length / 4)
+}
+
+/**
+ * Estimate cost based on model and tokens
+ */
+export function estimateCost(inputTokens: number, outputTokens: number, model: string): number {
+  // GPT-4o pricing (approximate)
+  const rates: Record<string, { input: number; output: number }> = {
+    'gpt-4o': { input: 0.005 / 1000, output: 0.015 / 1000 },
+    'gpt-4o-mini': { input: 0.00015 / 1000, output: 0.0006 / 1000 },
+    'gpt-4-turbo': { input: 0.01 / 1000, output: 0.03 / 1000 },
+  }
+
+  const rate = rates[model] || rates['gpt-4o']
+  return inputTokens * rate.input + outputTokens * rate.output
+}
+
+// Heartbeat event type
+export interface HeartbeatEvent {
+  type: 'heartbeat'
+  status: 'processing' | 'searching' | 'analyzing'
+  agent?: string
+  progress?: number
+}
+
+// Data event type
+export interface DataEvent<T> {
+  type: 'data'
+  payload: T
+}
+
+// Error event type
+export interface ErrorEvent {
+  type: 'error'
+  code: string
+  message: string
+}
+
+// Done event type
+export interface DoneEvent {
+  type: 'done'
+}
+
+export type StreamEvent<T> = HeartbeatEvent | DataEvent<T> | ErrorEvent | DoneEvent
+
+/**
+ * Create a streaming response with heartbeats
+ */
+export function createStreamingResponse<T>(
+  generator: () => AsyncGenerator<T>,
+  options?: {
+    heartbeatIntervalMs?: number
+    onHeartbeat?: (count: number) => HeartbeatEvent
+  }
+): ReadableStream<StreamEvent<T>> {
+  const heartbeatInterval = options?.heartbeatIntervalMs ?? STREAM_CONFIG.heartbeatIntervalMs
+
+  return new ReadableStream<StreamEvent<T>>({
+    async start(controller) {
+      let heartbeatCount = 0
+      let done = false
+
+      // Heartbeat timer
+      const heartbeatTimer = setInterval(() => {
+        if (!done) {
+          const event = options?.onHeartbeat?.(heartbeatCount) ?? {
+            type: 'heartbeat' as const,
+            status: 'processing' as const,
+          }
+          controller.enqueue(event)
+          heartbeatCount++
+        }
+      }, heartbeatInterval)
+
+      try {
+        for await (const item of generator()) {
+          controller.enqueue({ type: 'data', payload: item })
+        }
+        controller.enqueue({ type: 'done' })
+      } catch (error) {
+        controller.enqueue({
+          type: 'error',
+          code: 'STREAM_ERROR',
+          message: (error as Error).message,
+        })
+      } finally {
+        done = true
+        clearInterval(heartbeatTimer)
+        controller.close()
+      }
+    },
+  })
+}
+
+// Search budget tracker
+interface SearchBudgetState {
+  matchupSearches: number
+  agentSearches: Record<string, number>
+}
+
+export class SearchBudgetTracker {
+  private state: SearchBudgetState = {
+    matchupSearches: 0,
+    agentSearches: {},
+  }
+
+  canSearch(agent?: string): boolean {
+    if (!SEARCH_CONFIG.enabled) return false
+    if (this.state.matchupSearches >= SEARCH_CONFIG.budgetPerMatchup) return false
+    if (agent && (this.state.agentSearches[agent] ?? 0) >= SEARCH_CONFIG.budgetPerAgent) return false
+    return true
+  }
+
+  recordSearch(agent?: string): void {
+    this.state.matchupSearches++
+    if (agent) {
+      this.state.agentSearches[agent] = (this.state.agentSearches[agent] ?? 0) + 1
+    }
+  }
+
+  getStats(): { matchup: number; perAgent: Record<string, number> } {
+    return {
+      matchup: this.state.matchupSearches,
+      perAgent: { ...this.state.agentSearches },
+    }
+  }
+
+  reset(): void {
+    this.state = { matchupSearches: 0, agentSearches: {} }
+  }
+}

--- a/lib/terminal/engine/index.ts
+++ b/lib/terminal/engine/index.ts
@@ -12,10 +12,11 @@
 export { runAgents, type MatchupContext, type AgentRunResult } from './agent-runner'
 export {
   validateSourceIntegrity,
-  validateImplication,
-  validateLineEvidence,
-  validateEdgeLanguage,
-  type ValidationResult,
+  validateImplications,
+  validateLineFreshness,
+  validateNoEdgeWithoutLine,
+  validateAlert,
+  validateAlerts,
 } from './validators'
 export {
   calculateConfidence,

--- a/lib/terminal/engine/index.ts
+++ b/lib/terminal/engine/index.ts
@@ -1,0 +1,55 @@
+/**
+ * Terminal Engine
+ *
+ * Core engine for the Swantail Terminal:
+ * - Agent runner (aggregates findings from all agents)
+ * - Validators (source integrity, line freshness, etc.)
+ * - Confidence calculation (code-derived)
+ * - Provenance hashing (reproducibility)
+ * - Guardrails (limits, streaming, fallback)
+ */
+
+export { runAgents, type MatchupContext, type AgentRunResult } from './agent-runner'
+export {
+  validateSourceIntegrity,
+  validateImplication,
+  validateLineEvidence,
+  validateEdgeLanguage,
+  type ValidationResult,
+} from './validators'
+export {
+  calculateConfidence,
+  confidenceInputsFromFinding,
+  calculateFindingConfidence,
+  type ConfidenceInputs,
+} from './confidence'
+export {
+  hashContent,
+  hashObject,
+  buildProvenance,
+  verifyProvenance,
+  generateRequestId,
+} from './provenance'
+export {
+  REQUEST_LIMITS,
+  STREAM_CONFIG,
+  SEARCH_CONFIG,
+  GuardrailError,
+  checkRequestLimits,
+  estimateTokens,
+  estimateCost,
+  createStreamingResponse,
+  SearchBudgetTracker,
+  type HeartbeatEvent,
+  type DataEvent,
+  type ErrorEvent,
+  type DoneEvent,
+  type StreamEvent,
+} from './guardrails'
+export {
+  renderFindingsFallback,
+  formatFallbackForTerminal,
+  formatFallbackForApi,
+  shouldUseFallback,
+  type FallbackLine,
+} from './fallback-renderer'

--- a/lib/terminal/engine/provenance.ts
+++ b/lib/terminal/engine/provenance.ts
@@ -1,0 +1,129 @@
+import { createHash } from 'crypto'
+import type { Finding, AgentType, Provenance } from '../schemas'
+
+/**
+ * Provenance & Hashing
+ *
+ * Every response includes provenance for:
+ * - Reproducibility (same inputs → same outputs)
+ * - Debugging (trace what data was used)
+ * - Auditability (verify claims against sources)
+ */
+
+/**
+ * Hash content to 12-character hex string
+ */
+export function hashContent(content: string): string {
+  return createHash('sha256').update(content).digest('hex').slice(0, 12)
+}
+
+/**
+ * Hash an object by JSON stringifying with sorted keys
+ */
+export function hashObject(obj: unknown): string {
+  const json = JSON.stringify(obj, Object.keys(obj as object).sort())
+  return hashContent(json)
+}
+
+interface BuildProvenanceInput {
+  requestId: string
+  prompt: string
+  skillMds: Partial<Record<AgentType, string>>
+  findings: Finding[]
+  dataVersion: string
+  dataTimestamp: number
+  searchTimestamps: number[]
+  agentsInvoked: AgentType[]
+  agentsSilent: AgentType[]
+  cacheHits: number
+  cacheMisses: number
+  llmModel: string
+  llmTemperature: number
+}
+
+/**
+ * Build provenance object with all hashes for reproducibility
+ */
+export function buildProvenance(inputs: BuildProvenanceInput): Provenance {
+  // Hash each skill MD file
+  const skillMdHashes = Object.fromEntries(
+    Object.entries(inputs.skillMds).map(([agent, content]) => [
+      agent,
+      hashContent(content as string),
+    ])
+  ) as Record<AgentType, string>
+
+  // Hash the prompt
+  const promptHash = hashContent(inputs.prompt)
+
+  // Hash findings array (sorted by ID for determinism)
+  const sortedFindings = [...inputs.findings].sort((a, b) => a.id.localeCompare(b.id))
+  const findingsHash = hashContent(JSON.stringify(sortedFindings))
+
+  return {
+    request_id: inputs.requestId,
+    prompt_hash: promptHash,
+    skill_md_hashes: skillMdHashes,
+    findings_hash: findingsHash,
+    data_version: inputs.dataVersion,
+    data_timestamp: inputs.dataTimestamp,
+    search_timestamps: inputs.searchTimestamps,
+    agents_invoked: inputs.agentsInvoked,
+    agents_silent: inputs.agentsSilent,
+    cache_hits: inputs.cacheHits,
+    cache_misses: inputs.cacheMisses,
+    llm_model: inputs.llmModel,
+    llm_temperature: inputs.llmTemperature,
+  }
+}
+
+/**
+ * Verify provenance hashes match expected values
+ * Used for debugging/replay scenarios
+ */
+export function verifyProvenance(
+  provenance: Provenance,
+  inputs: {
+    prompt: string
+    skillMds: Partial<Record<AgentType, string>>
+    findings: Finding[]
+  }
+): { valid: boolean; mismatches: string[] } {
+  const mismatches: string[] = []
+
+  // Check prompt hash
+  const expectedPromptHash = hashContent(inputs.prompt)
+  if (provenance.prompt_hash !== expectedPromptHash) {
+    mismatches.push(`prompt_hash: expected ${expectedPromptHash}, got ${provenance.prompt_hash}`)
+  }
+
+  // Check skill MD hashes
+  for (const [agent, content] of Object.entries(inputs.skillMds)) {
+    const expectedHash = hashContent(content as string)
+    const actualHash = provenance.skill_md_hashes[agent as AgentType]
+    if (actualHash !== expectedHash) {
+      mismatches.push(`skill_md_hashes.${agent}: expected ${expectedHash}, got ${actualHash}`)
+    }
+  }
+
+  // Check findings hash
+  const sortedFindings = [...inputs.findings].sort((a, b) => a.id.localeCompare(b.id))
+  const expectedFindingsHash = hashContent(JSON.stringify(sortedFindings))
+  if (provenance.findings_hash !== expectedFindingsHash) {
+    mismatches.push(`findings_hash: expected ${expectedFindingsHash}, got ${provenance.findings_hash}`)
+  }
+
+  return {
+    valid: mismatches.length === 0,
+    mismatches,
+  }
+}
+
+/**
+ * Generate a unique request ID
+ */
+export function generateRequestId(): string {
+  const timestamp = Date.now().toString(36)
+  const random = Math.random().toString(36).slice(2, 8)
+  return `req-${timestamp}-${random}`
+}

--- a/lib/terminal/engine/validators.ts
+++ b/lib/terminal/engine/validators.ts
@@ -1,0 +1,292 @@
+import {
+  AlertSchema,
+  type Alert,
+  type Finding,
+  type LLMFindingOutput,
+  isLineEvidence,
+  validateImplicationsForAgent,
+} from '../schemas'
+import { calculateConfidence, type ConfidenceInputs } from './confidence'
+
+/**
+ * Validators
+ *
+ * All validators enforce the contract layer:
+ * 1. Zod .strict() - no extra fields (built into schemas)
+ * 2. Source integrity - no orphan sources
+ * 3. Line freshness - within TTL per line type
+ * 4. Edge language - blocked without LineEvidence
+ * 5. Implications allowlist - per agent
+ * 6. Confidence immutability - code-derived only
+ * 7. ID/Agent immutability - from Finding only
+ */
+
+// Line TTL per type
+export const LINE_TTL = {
+  spread: 30 * 60 * 1000,      // 30 min
+  total: 30 * 60 * 1000,       // 30 min
+  prop: 15 * 60 * 1000,        // 15 min (more volatile)
+  moneyline: 60 * 60 * 1000,   // 1 hr
+} as const
+
+// Edge language patterns that require LineEvidence
+const EDGE_LANGUAGE_PATTERNS = [
+  /\bedge\b/i,
+  /\bvalue\b/i,
+  /\bmispriced\b/i,
+  /\bexploit\b/i,
+  /\bsharp\b/i,
+  /\block\b/i,
+]
+
+export class ValidationError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly details?: Record<string, unknown>
+  ) {
+    super(message)
+    this.name = 'ValidationError'
+  }
+}
+
+/**
+ * Validate source integrity: no orphan sources, all evidence has sources
+ */
+export function validateSourceIntegrity(alert: Alert): void {
+  const evidenceRefs = new Set(alert.evidence.map(e => e.source_ref))
+  const sourceRefs = new Set(alert.sources.map(s => s.ref))
+
+  // Check for orphan sources (source without matching evidence)
+  for (const ref of sourceRefs) {
+    if (!evidenceRefs.has(ref)) {
+      throw new ValidationError(
+        'ORPHAN_SOURCE',
+        `Orphan source: ${ref} not referenced in evidence`,
+        { orphanRef: ref }
+      )
+    }
+  }
+
+  // Check for evidence without source
+  for (const ref of evidenceRefs) {
+    if (!sourceRefs.has(ref)) {
+      throw new ValidationError(
+        'MISSING_SOURCE',
+        `Missing source for evidence ref: ${ref}`,
+        { missingRef: ref }
+      )
+    }
+  }
+}
+
+/**
+ * Validate line evidence freshness against TTL
+ */
+export function validateLineFreshness(alert: Alert): void {
+  const now = Date.now()
+
+  for (const evidence of alert.evidence) {
+    if (isLineEvidence(evidence)) {
+      const ttl = LINE_TTL[evidence.line_type]
+      const age = now - evidence.line_timestamp
+
+      if (age > ttl) {
+        throw new ValidationError(
+          'STALE_LINE',
+          `Stale line evidence: ${evidence.line_type} is ${Math.round(age / 1000 / 60)}min old (TTL: ${ttl / 1000 / 60}min)`,
+          {
+            lineType: evidence.line_type,
+            age,
+            ttl,
+            timestamp: evidence.line_timestamp,
+          }
+        )
+      }
+    }
+  }
+}
+
+/**
+ * Validate no edge language without LineEvidence
+ */
+export function validateNoEdgeWithoutLine(alert: Alert): void {
+  const hasLineEvidence = alert.evidence.some(e => isLineEvidence(e))
+
+  for (const pattern of EDGE_LANGUAGE_PATTERNS) {
+    if (pattern.test(alert.claim) && !hasLineEvidence) {
+      throw new ValidationError(
+        'EDGE_LANGUAGE_WITHOUT_LINE',
+        `Claim uses edge language "${pattern}" but no LineEvidence provided`,
+        { claim: alert.claim, pattern: pattern.toString() }
+      )
+    }
+  }
+}
+
+/**
+ * Validate implications against agent allowlist
+ */
+export function validateImplications(alert: Alert): void {
+  const result = validateImplicationsForAgent(alert.agent, alert.implications)
+
+  if (!result.valid) {
+    throw new ValidationError(
+      'INVALID_IMPLICATIONS',
+      `Agent ${alert.agent} cannot imply markets: ${result.invalid.join(', ')}`,
+      { agent: alert.agent, invalidImplications: result.invalid }
+    )
+  }
+}
+
+/**
+ * Validate ID and agent match the finding (immutability)
+ */
+export function validateIdAgentMatch(alert: Alert, finding: Finding): void {
+  if (alert.id !== finding.id) {
+    throw new ValidationError(
+      'ID_MISMATCH',
+      `Alert ID mismatch: expected ${finding.id}, got ${alert.id}`,
+      { expected: finding.id, actual: alert.id }
+    )
+  }
+
+  if (alert.agent !== finding.agent) {
+    throw new ValidationError(
+      'AGENT_MISMATCH',
+      `Alert agent mismatch: expected ${finding.agent}, got ${alert.agent}`,
+      { expected: finding.agent, actual: alert.agent }
+    )
+  }
+}
+
+/**
+ * Validate confidence matches code-derived value (immutability)
+ */
+export function validateConfidenceImmutability(
+  alert: Alert,
+  expectedConfidence: number
+): void {
+  // Allow small floating point difference
+  if (Math.abs(alert.confidence - expectedConfidence) > 0.001) {
+    throw new ValidationError(
+      'CONFIDENCE_MODIFIED',
+      `Confidence was modified: expected ${expectedConfidence}, got ${alert.confidence}`,
+      { expected: expectedConfidence, actual: alert.confidence }
+    )
+  }
+}
+
+/**
+ * Validate freshness matches source age
+ */
+export function validateFreshnessConsistency(alert: Alert): void {
+  const now = Date.now()
+  const ONE_DAY = 24 * 60 * 60 * 1000
+  const ONE_WEEK = 7 * ONE_DAY
+
+  // Get oldest source timestamp
+  const oldestTimestamp = Math.min(...alert.sources.map(s => s.data_timestamp))
+  const age = now - oldestTimestamp
+
+  // Check freshness matches age
+  if (alert.freshness === 'live' && age > ONE_DAY) {
+    throw new ValidationError(
+      'FRESHNESS_MISMATCH',
+      `Freshness claimed "live" but oldest source is ${Math.round(age / ONE_DAY)} days old`,
+      { freshness: alert.freshness, age, oldestTimestamp }
+    )
+  }
+
+  if (alert.freshness === 'weekly' && age > ONE_WEEK) {
+    throw new ValidationError(
+      'FRESHNESS_MISMATCH',
+      `Freshness claimed "weekly" but oldest source is ${Math.round(age / ONE_DAY)} days old`,
+      { freshness: alert.freshness, age, oldestTimestamp }
+    )
+  }
+}
+
+/**
+ * Full validation chain for an alert
+ */
+export function validateAlert(
+  alert: Alert,
+  finding: Finding,
+  expectedConfidence: number
+): void {
+  // 1. Zod strict parse (no extra fields)
+  AlertSchema.parse(alert)
+
+  // 2. ID/Agent immutability
+  validateIdAgentMatch(alert, finding)
+
+  // 3. Confidence immutability
+  validateConfidenceImmutability(alert, expectedConfidence)
+
+  // 4. Source integrity
+  validateSourceIntegrity(alert)
+
+  // 5. Line freshness
+  validateLineFreshness(alert)
+
+  // 6. Implications allowlist
+  validateImplications(alert)
+
+  // 7. No edge language without line
+  validateNoEdgeWithoutLine(alert)
+
+  // 8. Freshness consistency
+  validateFreshnessConsistency(alert)
+}
+
+/**
+ * Batch validate all alerts
+ */
+export function validateAlerts(
+  alerts: Alert[],
+  findings: Finding[],
+  confidences: Map<string, number>
+): { valid: Alert[]; errors: Array<{ alertId: string; error: ValidationError }> } {
+  const valid: Alert[] = []
+  const errors: Array<{ alertId: string; error: ValidationError }> = []
+
+  const findingMap = new Map(findings.map(f => [f.id, f]))
+
+  for (const alert of alerts) {
+    const finding = findingMap.get(alert.id)
+    if (!finding) {
+      errors.push({
+        alertId: alert.id,
+        error: new ValidationError(
+          'MISSING_FINDING',
+          `No finding found for alert: ${alert.id}`,
+          { alertId: alert.id }
+        ),
+      })
+      continue
+    }
+
+    const expectedConfidence = confidences.get(alert.id) ?? 0.5
+
+    try {
+      validateAlert(alert, finding, expectedConfidence)
+      valid.push(alert)
+    } catch (e) {
+      if (e instanceof ValidationError) {
+        errors.push({ alertId: alert.id, error: e })
+      } else {
+        errors.push({
+          alertId: alert.id,
+          error: new ValidationError(
+            'UNKNOWN_ERROR',
+            (e as Error).message,
+            { originalError: e }
+          ),
+        })
+      }
+    }
+  }
+
+  return { valid, errors }
+}

--- a/lib/terminal/schemas/alert.ts
+++ b/lib/terminal/schemas/alert.ts
@@ -1,0 +1,163 @@
+import { z } from 'zod'
+import { EvidenceSchema } from './evidence'
+import { AgentTypeSchema, type Finding } from './finding'
+import { AnyImplicationSchema } from './implications'
+import { renderClaim } from './claim'
+import type { LLMFindingOutput, LLMOutput } from './llm-output'
+
+/**
+ * Alert Schema
+ *
+ * Alerts are ASSEMBLED via merge, not created by LLM:
+ *   Alert = merge(CodeDerivedFields, LLMOutputByFindingId)
+ *
+ * Code-derived fields (immutable, from Finding):
+ *   - id, agent, evidence, sources, confidence, freshness
+ *
+ * LLM-derived fields (constrained):
+ *   - severity, claim, implications, suppressions
+ */
+
+// Source schema with strict fields
+export const SourceSchema = z.object({
+  type: z.enum(['local', 'web', 'line']),
+  ref: z.string(),
+  data_version: z.string(),
+  data_timestamp: z.number(),
+  search_timestamp: z.number().optional(),
+  quote_snippet: z.string().optional(),
+}).strict()
+
+// Code-derived fields (from Finding + context)
+export const CodeDerivedAlertFieldsSchema = z.object({
+  id: z.string(),
+  agent: AgentTypeSchema,
+  evidence: z.array(EvidenceSchema).min(1),
+  sources: z.array(SourceSchema).min(1),
+  confidence: z.number().min(0).max(1),
+  freshness: z.enum(['live', 'weekly', 'stale']),
+}).strict()
+
+// LLM-derived fields (constrained)
+export const LLMDerivedAlertFieldsSchema = z.object({
+  severity: z.enum(['high', 'medium']),
+  claim: z.string().max(200),
+  implications: z.array(AnyImplicationSchema).min(1).max(5),
+  suppressions: z.array(z.string()),
+}).strict()
+
+// Full Alert = merge of both
+export const AlertSchema = CodeDerivedAlertFieldsSchema.merge(LLMDerivedAlertFieldsSchema)
+
+export type Source = z.infer<typeof SourceSchema>
+export type CodeDerivedAlertFields = z.infer<typeof CodeDerivedAlertFieldsSchema>
+export type LLMDerivedAlertFields = z.infer<typeof LLMDerivedAlertFieldsSchema>
+export type Alert = z.infer<typeof AlertSchema>
+
+/**
+ * Build code-derived fields from a Finding
+ */
+export function buildCodeDerivedFields(
+  finding: Finding,
+  confidence: number,
+  dataVersion: string
+): CodeDerivedAlertFields {
+  // Derive freshness from source timestamp
+  const now = Date.now()
+  const age = now - finding.source_timestamp
+  const ONE_DAY = 24 * 60 * 60 * 1000
+  const ONE_WEEK = 7 * ONE_DAY
+
+  let freshness: 'live' | 'weekly' | 'stale'
+  if (age < ONE_DAY) {
+    freshness = 'live'
+  } else if (age < ONE_WEEK) {
+    freshness = 'weekly'
+  } else {
+    freshness = 'stale'
+  }
+
+  // Build evidence from finding
+  const evidence = [{
+    stat: finding.stat,
+    value_num: finding.value_num,
+    value_str: finding.value_str,
+    value_type: finding.value_type,
+    comparison: finding.comparison_context,
+    source_type: finding.source_type,
+    source_ref: finding.source_ref,
+    quote_snippet: finding.quote_snippet,
+  }]
+
+  // Build source from finding
+  const sources = [{
+    type: finding.source_type,
+    ref: finding.source_ref,
+    data_version: dataVersion,
+    data_timestamp: finding.source_timestamp,
+    search_timestamp: finding.source_type === 'web' ? finding.source_timestamp : undefined,
+    quote_snippet: finding.quote_snippet,
+  }]
+
+  return {
+    id: finding.id,
+    agent: finding.agent,
+    evidence: evidence as CodeDerivedAlertFields['evidence'],
+    sources: sources as CodeDerivedAlertFields['sources'],
+    confidence,
+    freshness,
+  }
+}
+
+/**
+ * Merge code-derived fields with LLM output to create Alert
+ * This is the ONLY way to create an Alert
+ */
+export function assembleAlert(
+  codeDerived: CodeDerivedAlertFields,
+  llmOutput: LLMFindingOutput
+): Alert {
+  return {
+    ...codeDerived,
+    severity: llmOutput.severity,
+    claim: renderClaim(llmOutput.claim_parts),
+    implications: llmOutput.implications,
+    suppressions: llmOutput.suppressions,
+  }
+}
+
+/**
+ * Assemble all alerts from findings and LLM output
+ * Throws if LLM output has missing/extra keys
+ */
+export function assembleAlerts(
+  findings: Finding[],
+  llmOutput: LLMOutput,
+  confidences: Map<string, number>,
+  dataVersion: string
+): Alert[] {
+  const alerts: Alert[] = []
+
+  for (const finding of findings) {
+    const llmFinding = llmOutput[finding.id]
+    if (!llmFinding) {
+      throw new Error(`LLM output missing for finding: ${finding.id}`)
+    }
+
+    const confidence = confidences.get(finding.id) ?? 0.5
+    const codeDerived = buildCodeDerivedFields(finding, confidence, dataVersion)
+    const alert = assembleAlert(codeDerived, llmFinding)
+
+    alerts.push(alert)
+  }
+
+  // Check for extra LLM outputs
+  const findingIds = new Set(findings.map(f => f.id))
+  for (const llmId of Object.keys(llmOutput)) {
+    if (!findingIds.has(llmId)) {
+      throw new Error(`LLM output contains unknown finding_id: ${llmId}`)
+    }
+  }
+
+  return alerts
+}

--- a/lib/terminal/schemas/claim.ts
+++ b/lib/terminal/schemas/claim.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod'
+
+export const MetricSchema = z.enum([
+  'receiving_epa', 'rushing_epa', 'pass_block_win_rate',
+  'pressure_rate', 'target_share', 'snap_count',
+  'red_zone_epa', 'epa_allowed', 'completion_rate',
+  'yards_per_attempt', 'sack_rate', 'passer_rating',
+  'yards_after_contact', 'separation', 'contested_catch_rate',
+  'route_participation', 'red_zone_targets',
+])
+
+export const ClaimPartsSchema = z.object({
+  metrics: z.array(MetricSchema).min(1),
+  direction: z.enum(['positive', 'negative', 'neutral']),
+  comparator: z.enum(['ranks', 'exceeds', 'trails', 'matches', 'diverges_from']),
+  rank_or_percentile: z.object({
+    type: z.enum(['rank', 'percentile']),
+    value: z.number(),
+    scope: z.enum(['league', 'position', 'conference', 'division']),
+    direction: z.enum(['top', 'bottom']),
+  }).strict().optional(),
+  comparison_target: z.enum([
+    'league_average', 'opponent_average', 'position_average',
+    'season_baseline', 'historical_self'
+  ]).optional(),
+  context_qualifier: z.enum([
+    'in_division', 'at_home', 'as_underdog', 'in_primetime',
+    'vs_top_10_defense', 'with_current_qb'
+  ]).optional(),
+}).strict()
+
+export type ClaimParts = z.infer<typeof ClaimPartsSchema>
+
+// Display name mappings
+const METRIC_DISPLAY: Record<string, string> = {
+  receiving_epa: 'Receiving EPA',
+  rushing_epa: 'Rushing EPA',
+  pass_block_win_rate: 'Pass Block Win Rate',
+  pressure_rate: 'Pressure Rate',
+  target_share: 'Target Share',
+  snap_count: 'Snap Count',
+  red_zone_epa: 'Red Zone EPA',
+  epa_allowed: 'EPA Allowed',
+  completion_rate: 'Completion Rate',
+  yards_per_attempt: 'Yards Per Attempt',
+  sack_rate: 'Sack Rate',
+  passer_rating: 'Passer Rating',
+  yards_after_contact: 'Yards After Contact',
+  separation: 'Separation',
+  contested_catch_rate: 'Contested Catch Rate',
+  route_participation: 'Route Participation',
+  red_zone_targets: 'Red Zone Targets',
+}
+
+const COMPARISON_DISPLAY: Record<string, string> = {
+  league_average: 'league average',
+  opponent_average: 'opponent average',
+  position_average: 'position average',
+  season_baseline: 'season baseline',
+  historical_self: 'historical self',
+}
+
+const QUALIFIER_DISPLAY: Record<string, string> = {
+  in_division: 'in division games',
+  at_home: 'at home',
+  as_underdog: 'as underdog',
+  in_primetime: 'in primetime',
+  vs_top_10_defense: 'vs top 10 defense',
+  with_current_qb: 'with current QB',
+}
+
+export function renderClaim(parts: ClaimParts): string {
+  const metricNames = parts.metrics.map(m => METRIC_DISPLAY[m] || m).join(' + ')
+
+  let claim = metricNames
+
+  if (parts.rank_or_percentile) {
+    const r = parts.rank_or_percentile
+    claim += ` ${parts.comparator} ${r.direction} ${r.value}`
+    claim += r.type === 'rank' ? ` in ${r.scope}` : 'th percentile'
+  }
+
+  if (parts.comparison_target) {
+    claim += ` vs ${COMPARISON_DISPLAY[parts.comparison_target]}`
+  }
+
+  if (parts.context_qualifier) {
+    claim += ` (${QUALIFIER_DISPLAY[parts.context_qualifier]})`
+  }
+
+  return claim
+}

--- a/lib/terminal/schemas/evidence.ts
+++ b/lib/terminal/schemas/evidence.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod'
+
+// Base evidence fields shared by all evidence types
+const BaseEvidenceFields = {
+  stat: z.string(),
+  value_num: z.number().optional(),
+  value_str: z.string().optional(),
+  value_type: z.enum(['numeric', 'string']),
+  comparison: z.string(),
+  source_ref: z.string(),
+  quote_snippet: z.string().optional(),
+}
+
+// Standard evidence (local or web source)
+export const LocalEvidenceSchema = z.object({
+  ...BaseEvidenceFields,
+  source_type: z.literal('local'),
+}).strict()
+
+export const WebEvidenceSchema = z.object({
+  ...BaseEvidenceFields,
+  source_type: z.literal('web'),
+  quote_snippet: z.string(), // Required for web
+}).strict()
+
+// Line evidence with betting-specific fields
+export const LineEvidenceSchema = z.object({
+  ...BaseEvidenceFields,
+  source_type: z.literal('line'),
+  line_type: z.enum(['spread', 'total', 'prop', 'moneyline']),
+  line_value: z.number(),
+  line_odds: z.number(),
+  book: z.string(),
+  line_timestamp: z.number(),
+  line_ttl: z.number(),
+}).strict()
+
+// Discriminated union by source_type
+export const EvidenceSchema = z.discriminatedUnion('source_type', [
+  LocalEvidenceSchema,
+  WebEvidenceSchema,
+  LineEvidenceSchema,
+])
+
+export type LocalEvidence = z.infer<typeof LocalEvidenceSchema>
+export type WebEvidence = z.infer<typeof WebEvidenceSchema>
+export type LineEvidence = z.infer<typeof LineEvidenceSchema>
+export type Evidence = z.infer<typeof EvidenceSchema>
+
+// Type guard for LineEvidence
+export function isLineEvidence(e: Evidence): e is LineEvidence {
+  return e.source_type === 'line'
+}

--- a/lib/terminal/schemas/finding.ts
+++ b/lib/terminal/schemas/finding.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+
+export const AgentTypeSchema = z.enum(['epa', 'pressure', 'weather', 'qb', 'hb', 'wr', 'te'])
+export type AgentType = z.infer<typeof AgentTypeSchema>
+
+export const FindingSchema = z.object({
+  id: z.string(),
+  agent: AgentTypeSchema,
+  type: z.string(),
+  stat: z.string(),
+  value_num: z.number().optional(),
+  value_str: z.string().optional(),
+  value_type: z.enum(['numeric', 'string']),
+  threshold_met: z.string(),
+  comparison_context: z.string(),
+  source_ref: z.string(),
+  source_type: z.enum(['local', 'web']),
+  source_timestamp: z.number(),
+  quote_snippet: z.string().optional(),
+}).strict()
+
+export type Finding = z.infer<typeof FindingSchema>

--- a/lib/terminal/schemas/implications.ts
+++ b/lib/terminal/schemas/implications.ts
@@ -1,0 +1,93 @@
+import { z } from 'zod'
+import type { AgentType } from './finding'
+
+// Per-agent implication enums - deterministic validation
+export const EpaImplicationSchema = z.enum([
+  'wr_receptions_over', 'wr_receptions_under',
+  'wr_yards_over', 'wr_yards_under',
+  'rb_yards_over', 'rb_yards_under',
+  'te_receptions_over', 'te_yards_over',
+  'team_total_over', 'team_total_under',
+])
+
+export const PressureImplicationSchema = z.enum([
+  'qb_sacks_over', 'qb_sacks_under',
+  'qb_ints_over', 'qb_pass_yards_under',
+  'def_sacks_over',
+])
+
+export const WeatherImplicationSchema = z.enum([
+  'game_total_under', 'pass_yards_under', 'field_goals_over',
+])
+
+export const QbImplicationSchema = z.enum([
+  'qb_pass_yards_over', 'qb_pass_yards_under',
+  'qb_pass_tds_over', 'qb_pass_tds_under',
+  'qb_completions_over', 'qb_completions_under',
+  'qb_ints_over',
+])
+
+export const HbImplicationSchema = z.enum([
+  'rb_rush_yards_over', 'rb_rush_yards_under',
+  'rb_receptions_over', 'rb_rush_attempts_over',
+  'rb_tds_over',
+])
+
+export const WrImplicationSchema = z.enum([
+  'wr_receptions_over', 'wr_receptions_under',
+  'wr_yards_over', 'wr_yards_under',
+  'wr_tds_over', 'wr_longest_reception_over',
+])
+
+export const TeImplicationSchema = z.enum([
+  'te_receptions_over', 'te_receptions_under',
+  'te_yards_over', 'te_yards_under',
+  'te_tds_over',
+])
+
+// Map agent → implication schema
+export const IMPLICATION_SCHEMAS: Record<AgentType, z.ZodEnum<[string, ...string[]]>> = {
+  epa: EpaImplicationSchema,
+  pressure: PressureImplicationSchema,
+  weather: WeatherImplicationSchema,
+  qb: QbImplicationSchema,
+  hb: HbImplicationSchema,
+  wr: WrImplicationSchema,
+  te: TeImplicationSchema,
+}
+
+// Get allowed implications for an agent
+export function getImplicationSchema(agent: AgentType) {
+  return IMPLICATION_SCHEMAS[agent]
+}
+
+// Validate implications against agent's allowlist
+export function validateImplicationsForAgent(
+  agent: AgentType,
+  implications: string[]
+): { valid: boolean; invalid: string[] } {
+  const schema = IMPLICATION_SCHEMAS[agent]
+  const allowedValues = schema.options as readonly string[]
+  const invalid = implications.filter(imp => !allowedValues.includes(imp))
+  return { valid: invalid.length === 0, invalid }
+}
+
+// All possible implications (union)
+export const AnyImplicationSchema = z.enum([
+  ...EpaImplicationSchema.options,
+  ...PressureImplicationSchema.options,
+  ...WeatherImplicationSchema.options,
+  ...QbImplicationSchema.options,
+  ...HbImplicationSchema.options,
+  ...WrImplicationSchema.options,
+  ...TeImplicationSchema.options,
+])
+
+export type EpaImplication = z.infer<typeof EpaImplicationSchema>
+export type PressureImplication = z.infer<typeof PressureImplicationSchema>
+export type WeatherImplication = z.infer<typeof WeatherImplicationSchema>
+export type QbImplication = z.infer<typeof QbImplicationSchema>
+export type HbImplication = z.infer<typeof HbImplicationSchema>
+export type WrImplication = z.infer<typeof WrImplicationSchema>
+export type TeImplication = z.infer<typeof TeImplicationSchema>
+export type AnyImplication = z.infer<typeof AnyImplicationSchema>

--- a/lib/terminal/schemas/index.ts
+++ b/lib/terminal/schemas/index.ts
@@ -79,3 +79,29 @@ export {
   ProvenanceSchema,
   type Provenance,
 } from './provenance'
+
+// Script - correlated parlay output from build command
+export {
+  LegSchema,
+  CorrelationTypeSchema,
+  ScriptSchema,
+  BuildResultSchema,
+  identifyCorrelations,
+  type Leg,
+  type CorrelationType,
+  type Script,
+  type BuildResult,
+} from './script'
+
+// Ladder - tiered prop bet output from bet command
+export {
+  RungSchema,
+  RiskTierSchema,
+  LadderSchema,
+  BetResultSchema,
+  organizeLadders,
+  type Rung,
+  type RiskTier,
+  type Ladder,
+  type BetResult,
+} from './ladder'

--- a/lib/terminal/schemas/index.ts
+++ b/lib/terminal/schemas/index.ts
@@ -1,0 +1,81 @@
+// Evidence types with discriminated union
+export {
+  EvidenceSchema,
+  LocalEvidenceSchema,
+  WebEvidenceSchema,
+  LineEvidenceSchema,
+  isLineEvidence,
+  type Evidence,
+  type LocalEvidence,
+  type WebEvidence,
+  type LineEvidence,
+} from './evidence'
+
+// Finding - the ONLY raw input to analyst
+export {
+  FindingSchema,
+  AgentTypeSchema,
+  type Finding,
+  type AgentType,
+} from './finding'
+
+// Claim parts - structured, not free text
+export {
+  ClaimPartsSchema,
+  MetricSchema,
+  renderClaim,
+  type ClaimParts,
+} from './claim'
+
+// Implications - per-agent enums for deterministic validation
+export {
+  EpaImplicationSchema,
+  PressureImplicationSchema,
+  WeatherImplicationSchema,
+  QbImplicationSchema,
+  HbImplicationSchema,
+  WrImplicationSchema,
+  TeImplicationSchema,
+  AnyImplicationSchema,
+  IMPLICATION_SCHEMAS,
+  getImplicationSchema,
+  validateImplicationsForAgent,
+  type EpaImplication,
+  type PressureImplication,
+  type WeatherImplication,
+  type QbImplication,
+  type HbImplication,
+  type WrImplication,
+  type TeImplication,
+  type AnyImplication,
+} from './implications'
+
+// LLM output - keyed by finding_id, NOT free-form
+export {
+  LLMOutputSchema,
+  LLMFindingOutputSchema,
+  validateLLMOutputKeys,
+  type LLMOutput,
+  type LLMFindingOutput,
+} from './llm-output'
+
+// Alert - assembled via merge(codeDerived, llmOutput)
+export {
+  AlertSchema,
+  SourceSchema,
+  CodeDerivedAlertFieldsSchema,
+  LLMDerivedAlertFieldsSchema,
+  buildCodeDerivedFields,
+  assembleAlert,
+  assembleAlerts,
+  type Alert,
+  type Source,
+  type CodeDerivedAlertFields,
+  type LLMDerivedAlertFields,
+} from './alert'
+
+// Provenance for reproducibility
+export {
+  ProvenanceSchema,
+  type Provenance,
+} from './provenance'

--- a/lib/terminal/schemas/ladder.ts
+++ b/lib/terminal/schemas/ladder.ts
@@ -1,0 +1,114 @@
+import { z } from 'zod'
+import { AgentTypeSchema } from './finding'
+
+/**
+ * Ladder Schema
+ *
+ * A Ladder is a tiered prop bet recommendation.
+ * Built from Alert[] by organizing into risk tiers.
+ *
+ * "bet" command output: Alert[] → Ladder[]
+ */
+
+// Individual rung on the ladder (a single prop bet)
+export const RungSchema = z.object({
+  alert_id: z.string(),
+  market: z.string(), // e.g., "Jamar Chase Over 85.5 Receiving Yards"
+  line: z.number().optional(), // e.g., 85.5
+  implied_probability: z.number().min(0).max(1).optional(),
+  agent: AgentTypeSchema,
+  rationale: z.string().max(200),
+}).strict()
+
+// Risk tier for grouping rungs
+export const RiskTierSchema = z.enum([
+  'safe',       // High probability, lower payout
+  'moderate',   // Balanced risk/reward
+  'aggressive', // Lower probability, higher payout
+])
+
+// A complete betting ladder
+export const LadderSchema = z.object({
+  id: z.string(),
+  name: z.string().max(100),
+  tier: RiskTierSchema,
+  rungs: z.array(RungSchema).min(1).max(5),
+  total_implied_probability: z.number().min(0).max(1).optional(),
+  recommended_stake_pct: z.number().min(0).max(100).optional(), // % of bankroll
+  provenance_hash: z.string(),
+}).strict()
+
+export type Rung = z.infer<typeof RungSchema>
+export type RiskTier = z.infer<typeof RiskTierSchema>
+export type Ladder = z.infer<typeof LadderSchema>
+
+/**
+ * Bet result from bet command
+ */
+export const BetResultSchema = z.object({
+  request_id: z.string(),
+  ladders: z.array(LadderSchema),
+  alerts_used: z.array(z.string()), // Alert IDs included
+  alerts_excluded: z.array(z.string()), // Alert IDs not suitable for ladders
+  bet_timestamp: z.number(),
+  provenance_hash: z.string(),
+}).strict()
+
+export type BetResult = z.infer<typeof BetResultSchema>
+
+/**
+ * Organize alerts into risk-tiered ladders
+ */
+export function organizeLadders(
+  alertIds: string[],
+  alertConfidences: Map<string, number>,
+  alertSeverities: Map<string, 'high' | 'medium'>
+): { tier: RiskTier; ids: string[]; name: string }[] {
+  const ladders: { tier: RiskTier; ids: string[]; name: string }[] = []
+
+  // Safe tier: high confidence (>= 0.7) + high severity
+  const safeIds = alertIds.filter(id => {
+    const conf = alertConfidences.get(id) || 0
+    const sev = alertSeverities.get(id)
+    return conf >= 0.7 && sev === 'high'
+  })
+
+  if (safeIds.length > 0) {
+    ladders.push({
+      tier: 'safe',
+      ids: safeIds.slice(0, 3),
+      name: 'High Confidence Picks',
+    })
+  }
+
+  // Moderate tier: medium confidence (0.5-0.7) or medium severity
+  const moderateIds = alertIds.filter(id => {
+    const conf = alertConfidences.get(id) || 0
+    const sev = alertSeverities.get(id)
+    return (conf >= 0.5 && conf < 0.7) || sev === 'medium'
+  })
+
+  if (moderateIds.length > 0) {
+    ladders.push({
+      tier: 'moderate',
+      ids: moderateIds.slice(0, 4),
+      name: 'Balanced Value Plays',
+    })
+  }
+
+  // Aggressive tier: lower confidence but actionable
+  const aggressiveIds = alertIds.filter(id => {
+    const conf = alertConfidences.get(id) || 0
+    return conf < 0.5 && conf >= 0.3
+  })
+
+  if (aggressiveIds.length > 0) {
+    ladders.push({
+      tier: 'aggressive',
+      ids: aggressiveIds.slice(0, 3),
+      name: 'High Upside Longshots',
+    })
+  }
+
+  return ladders
+}

--- a/lib/terminal/schemas/llm-output.ts
+++ b/lib/terminal/schemas/llm-output.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod'
+import { ClaimPartsSchema } from './claim'
+import { AnyImplicationSchema } from './implications'
+
+/**
+ * LLM Output Schema
+ *
+ * The LLM outputs a MAP keyed by finding_id, NOT free-form Alert objects.
+ * This prevents the LLM from:
+ * - Inventing new finding IDs
+ * - Relabeling agents
+ * - Modifying code-derived fields
+ *
+ * The code merges this output with code-derived fields to produce Alert[].
+ */
+
+// What the LLM outputs for a single finding
+export const LLMFindingOutputSchema = z.object({
+  severity: z.enum(['high', 'medium']),
+  claim_parts: ClaimPartsSchema,
+  implications: z.array(AnyImplicationSchema).min(1).max(5),
+  suppressions: z.array(z.string()),
+}).strict()
+
+// LLM output is a map: finding_id → LLMFindingOutput
+// This enforces that LLM can only annotate existing findings
+export const LLMOutputSchema = z.record(
+  z.string(), // finding_id - must match a Finding.id
+  LLMFindingOutputSchema
+).refine(
+  (data) => Object.keys(data).length > 0,
+  { message: 'LLM output must contain at least one finding annotation' }
+)
+
+export type LLMFindingOutput = z.infer<typeof LLMFindingOutputSchema>
+export type LLMOutput = z.infer<typeof LLMOutputSchema>
+
+/**
+ * Validates that LLM output keys match provided finding IDs
+ */
+export function validateLLMOutputKeys(
+  llmOutput: LLMOutput,
+  findingIds: string[]
+): { valid: boolean; missing: string[]; extra: string[] } {
+  const outputKeys = new Set(Object.keys(llmOutput))
+  const expectedKeys = new Set(findingIds)
+
+  const missing = findingIds.filter(id => !outputKeys.has(id))
+  const extra = Object.keys(llmOutput).filter(id => !expectedKeys.has(id))
+
+  return {
+    valid: missing.length === 0 && extra.length === 0,
+    missing,
+    extra,
+  }
+}

--- a/lib/terminal/schemas/provenance.ts
+++ b/lib/terminal/schemas/provenance.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+import { AgentTypeSchema } from './finding'
+
+export const ProvenanceSchema = z.object({
+  request_id: z.string(),
+  prompt_hash: z.string(),
+  skill_md_hashes: z.record(z.string(), z.string()),
+  findings_hash: z.string(),
+  data_version: z.string(),
+  data_timestamp: z.number(),
+  search_timestamps: z.array(z.number()),
+  agents_invoked: z.array(AgentTypeSchema),
+  agents_silent: z.array(AgentTypeSchema),
+  cache_hits: z.number(),
+  cache_misses: z.number(),
+  llm_model: z.string(),
+  llm_temperature: z.number(),
+}).strict()
+
+export type Provenance = z.infer<typeof ProvenanceSchema>

--- a/lib/terminal/schemas/script.ts
+++ b/lib/terminal/schemas/script.ts
@@ -1,0 +1,121 @@
+import { z } from 'zod'
+import { AgentTypeSchema } from './finding'
+
+/**
+ * Script Schema
+ *
+ * A Script is a correlated parlay recommendation.
+ * Built from Alert[] by identifying correlation patterns.
+ *
+ * "build" command output: Alert[] → Script[]
+ */
+
+// Individual leg in a parlay
+export const LegSchema = z.object({
+  alert_id: z.string(),
+  market: z.string(), // e.g., "WR Receiving Yards Over 75.5"
+  implied_probability: z.number().min(0).max(1).optional(),
+  correlation_factor: z.number().min(-1).max(1).optional(),
+  agent: AgentTypeSchema,
+}).strict()
+
+// Correlation type between legs
+export const CorrelationTypeSchema = z.enum([
+  'game_script',      // e.g., if team is trailing, more passing
+  'player_stack',     // e.g., QB + WR same team
+  'weather_cascade',  // e.g., wind affects multiple props
+  'defensive_funnel', // e.g., pressure forces quick throws
+  'volume_share',     // e.g., target share concentration
+])
+
+// A complete parlay script
+export const ScriptSchema = z.object({
+  id: z.string(),
+  name: z.string().max(100),
+  legs: z.array(LegSchema).min(2).max(6),
+  correlation_type: CorrelationTypeSchema,
+  correlation_explanation: z.string().max(300),
+  combined_confidence: z.number().min(0).max(1),
+  risk_level: z.enum(['conservative', 'moderate', 'aggressive']),
+  provenance_hash: z.string(),
+}).strict()
+
+export type Leg = z.infer<typeof LegSchema>
+export type CorrelationType = z.infer<typeof CorrelationTypeSchema>
+export type Script = z.infer<typeof ScriptSchema>
+
+/**
+ * Build result from build command
+ */
+export const BuildResultSchema = z.object({
+  request_id: z.string(),
+  scripts: z.array(ScriptSchema),
+  alerts_used: z.array(z.string()), // Alert IDs included
+  alerts_excluded: z.array(z.string()), // Alert IDs not correlated
+  build_timestamp: z.number(),
+  provenance_hash: z.string(),
+}).strict()
+
+export type BuildResult = z.infer<typeof BuildResultSchema>
+
+/**
+ * Identify correlation patterns between alerts
+ */
+export function identifyCorrelations(
+  alertIds: string[],
+  alertAgents: Map<string, string>,
+  alertImplications: Map<string, string[]>
+): { type: CorrelationType; ids: string[]; explanation: string }[] {
+  const correlations: { type: CorrelationType; ids: string[]; explanation: string }[] = []
+
+  // Weather cascade: weather + any passing-related alert
+  const weatherAlerts = alertIds.filter(id => alertAgents.get(id) === 'weather')
+  const passingAlerts = alertIds.filter(id => {
+    const agent = alertAgents.get(id)
+    return agent === 'qb' || agent === 'wr' || agent === 'te'
+  })
+
+  if (weatherAlerts.length > 0 && passingAlerts.length > 0) {
+    correlations.push({
+      type: 'weather_cascade',
+      ids: [...weatherAlerts, ...passingAlerts.slice(0, 2)],
+      explanation: 'Weather conditions affect passing game metrics across multiple positions',
+    })
+  }
+
+  // Defensive funnel: pressure + QB metrics
+  const pressureAlerts = alertIds.filter(id => alertAgents.get(id) === 'pressure')
+  const qbAlerts = alertIds.filter(id => alertAgents.get(id) === 'qb')
+
+  if (pressureAlerts.length > 0 && qbAlerts.length > 0) {
+    correlations.push({
+      type: 'defensive_funnel',
+      ids: [...pressureAlerts, ...qbAlerts],
+      explanation: 'Pass rush pressure correlates with QB performance metrics',
+    })
+  }
+
+  // Player stack: same position group (e.g., multiple WRs)
+  const wrAlerts = alertIds.filter(id => alertAgents.get(id) === 'wr')
+  if (wrAlerts.length >= 2) {
+    correlations.push({
+      type: 'volume_share',
+      ids: wrAlerts.slice(0, 3),
+      explanation: 'Target share concentration among receiving options',
+    })
+  }
+
+  // EPA-based game script
+  const epaAlerts = alertIds.filter(id => alertAgents.get(id) === 'epa')
+  const hbAlerts = alertIds.filter(id => alertAgents.get(id) === 'hb')
+
+  if (epaAlerts.length > 0 && hbAlerts.length > 0) {
+    correlations.push({
+      type: 'game_script',
+      ids: [...epaAlerts.slice(0, 2), ...hbAlerts.slice(0, 2)],
+      explanation: 'EPA efficiency patterns predict game script and usage',
+    })
+  }
+
+  return correlations
+}

--- a/lib/terminal/ui/command-parser.ts
+++ b/lib/terminal/ui/command-parser.ts
@@ -1,0 +1,237 @@
+/**
+ * Terminal Command Parser
+ *
+ * Parses user input into structured commands for the terminal.
+ */
+
+export type CommandType = 'matchup' | 'build' | 'bet' | 'help' | 'theme' | 'retry' | 'clear' | 'unknown'
+
+export interface ParsedCommand {
+  type: CommandType
+  raw: string
+  args: string[]
+  flags: Record<string, string | boolean>
+}
+
+// Matchup patterns
+const MATCHUP_AT_PATTERN = /^([a-zA-Z0-9]+)\s*@\s*([a-zA-Z0-9]+)$/
+const MATCHUP_VS_PATTERN = /^([a-zA-Z0-9]+)\s+vs\.?\s+([a-zA-Z0-9]+)$/i
+
+// Team abbreviation mappings
+const TEAM_ALIASES: Record<string, string> = {
+  '49ers': 'SF',
+  'niners': 'SF',
+  'seahawks': 'SEA',
+  'cardinals': 'ARI',
+  'rams': 'LAR',
+  'bears': 'CHI',
+  'lions': 'DET',
+  'packers': 'GB',
+  'vikings': 'MIN',
+  'cowboys': 'DAL',
+  'eagles': 'PHI',
+  'giants': 'NYG',
+  'commanders': 'WAS',
+  'falcons': 'ATL',
+  'panthers': 'CAR',
+  'saints': 'NO',
+  'buccaneers': 'TB',
+  'bucs': 'TB',
+  'chiefs': 'KC',
+  'raiders': 'LV',
+  'broncos': 'DEN',
+  'chargers': 'LAC',
+  'ravens': 'BAL',
+  'bengals': 'CIN',
+  'browns': 'CLE',
+  'steelers': 'PIT',
+  'texans': 'HOU',
+  'colts': 'IND',
+  'jaguars': 'JAX',
+  'jags': 'JAX',
+  'titans': 'TEN',
+  'bills': 'BUF',
+  'dolphins': 'MIA',
+  'fins': 'MIA',
+  'patriots': 'NE',
+  'pats': 'NE',
+  'jets': 'NYJ',
+}
+
+/**
+ * Normalize team name to abbreviation
+ */
+export function normalizeTeam(team: string): string {
+  const trimmed = team.trim()
+  const lower = trimmed.toLowerCase()
+  return TEAM_ALIASES[lower] || trimmed.toUpperCase()
+}
+
+/**
+ * Parse flags from args array
+ * e.g., ["--raw", "--max", "3"] -> { raw: true, max: "3" }
+ */
+function parseFlags(args: string[]): { cleanArgs: string[]; flags: Record<string, string | boolean> } {
+  const flags: Record<string, string | boolean> = {}
+  const cleanArgs: string[] = []
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+
+    if (arg.startsWith('--')) {
+      const key = arg.slice(2)
+      const nextArg = args[i + 1]
+
+      // Check if next arg is a value (doesn't start with -)
+      if (nextArg && !nextArg.startsWith('-')) {
+        flags[key] = nextArg
+        i++ // Skip the value
+      } else {
+        flags[key] = true
+      }
+    } else if (arg.startsWith('-') && arg.length === 2) {
+      const key = arg.slice(1)
+      flags[key] = true
+    } else {
+      cleanArgs.push(arg)
+    }
+  }
+
+  return { cleanArgs, flags }
+}
+
+/**
+ * Try to parse input as a matchup
+ */
+function parseMatchup(input: string): { away: string; home: string } | null {
+  // Try @ format: "SF @ SEA" or "49ers @ Seahawks"
+  const atMatch = input.match(MATCHUP_AT_PATTERN)
+  if (atMatch) {
+    return {
+      away: normalizeTeam(atMatch[1]),
+      home: normalizeTeam(atMatch[2]),
+    }
+  }
+
+  // Try vs format: "SF vs SEA" (first team away, second home - consistent with @)
+  const vsMatch = input.match(MATCHUP_VS_PATTERN)
+  if (vsMatch) {
+    return {
+      away: normalizeTeam(vsMatch[1]),
+      home: normalizeTeam(vsMatch[2]),
+    }
+  }
+
+  return null
+}
+
+/**
+ * Parse a command string into structured format
+ */
+export function parseCommand(input: string): ParsedCommand {
+  const trimmed = input.trim()
+
+  if (!trimmed) {
+    return { type: 'unknown', raw: '', args: [], flags: {} }
+  }
+
+  const parts = trimmed.split(/\s+/)
+  const firstWord = parts[0].toLowerCase()
+  const restParts = parts.slice(1)
+  const { cleanArgs, flags } = parseFlags(restParts)
+
+  // Check explicit commands first
+  switch (firstWord) {
+    case 'build':
+      return { type: 'build', raw: trimmed, args: cleanArgs, flags }
+
+    case 'bet':
+      return { type: 'bet', raw: trimmed, args: cleanArgs, flags }
+
+    case 'help':
+    case '?':
+      return { type: 'help', raw: trimmed, args: cleanArgs, flags }
+
+    case 'theme':
+      return { type: 'theme', raw: trimmed, args: cleanArgs, flags }
+
+    case 'retry':
+      return { type: 'retry', raw: trimmed, args: [], flags }
+
+    case 'clear':
+    case 'cls':
+      return { type: 'clear', raw: trimmed, args: [], flags }
+  }
+
+  // Check if it's a matchup
+  const matchup = parseMatchup(trimmed)
+  if (matchup) {
+    return {
+      type: 'matchup',
+      raw: trimmed,
+      args: [matchup.away, matchup.home],
+      flags: {},
+    }
+  }
+
+  // Unknown command
+  return { type: 'unknown', raw: trimmed, args: parts, flags }
+}
+
+/**
+ * Get help text for commands
+ */
+export function getHelpText(): string {
+  return `
+Available Commands
+──────────────────────────────────────────────────
+
+  [matchup]       Select game and trigger agent scan
+                  Examples: SF @ SEA, 49ers @ Seahawks, Chiefs vs Raiders
+
+  build           Generate correlated parlay scripts from alerts
+                  Flags: --max <n> (max legs), --raw (skip LLM)
+
+  bet [prop]      Generate prop ladder with agent commentary
+                  Examples: bet, bet chase receptions
+
+  help            Show this help message
+
+  theme [team]    Switch color theme to team colors
+                  Examples: theme SF, theme Seahawks
+
+  retry           Re-run the last command
+
+  clear           Clear the terminal output
+
+──────────────────────────────────────────────────
+`.trim()
+}
+
+/**
+ * Validate a matchup command
+ */
+export function validateMatchup(away: string, home: string): { valid: boolean; error?: string } {
+  const validTeams = new Set([
+    'SF', 'SEA', 'ARI', 'LAR', // NFC West
+    'CHI', 'DET', 'GB', 'MIN', // NFC North
+    'DAL', 'PHI', 'NYG', 'WAS', // NFC East
+    'ATL', 'CAR', 'NO', 'TB', // NFC South
+    'KC', 'LV', 'DEN', 'LAC', // AFC West
+    'BAL', 'CIN', 'CLE', 'PIT', // AFC North
+    'HOU', 'IND', 'JAX', 'TEN', // AFC South
+    'BUF', 'MIA', 'NE', 'NYJ', // AFC East
+  ])
+
+  if (!validTeams.has(away)) {
+    return { valid: false, error: `Unknown team: ${away}` }
+  }
+  if (!validTeams.has(home)) {
+    return { valid: false, error: `Unknown team: ${home}` }
+  }
+  if (away === home) {
+    return { valid: false, error: 'Away and home team cannot be the same' }
+  }
+
+  return { valid: true }
+}

--- a/lib/terminal/ui/index.ts
+++ b/lib/terminal/ui/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Terminal UI Module
+ *
+ * Exports all UI-related utilities for the terminal interface.
+ */
+
+export {
+  TEAM_THEMES,
+  DEFAULT_THEME,
+  getTeamTheme,
+  getThemeVars,
+  applyTheme,
+  type TeamTheme,
+} from './themes'
+
+export {
+  parseCommand,
+  normalizeTeam,
+  getHelpText,
+  validateMatchup,
+  type CommandType,
+  type ParsedCommand,
+} from './command-parser'

--- a/lib/terminal/ui/themes.ts
+++ b/lib/terminal/ui/themes.ts
@@ -1,0 +1,301 @@
+/**
+ * Team Color Themes
+ *
+ * Each team has primary and accent colors for terminal theming.
+ * Colors are applied dynamically based on the selected matchup.
+ */
+
+export interface TeamTheme {
+  name: string
+  abbreviation: string
+  primary: string   // Main background/text color
+  accent: string    // Highlight color
+  secondary: string // Muted variant
+}
+
+export const TEAM_THEMES: Record<string, TeamTheme> = {
+  // NFC West
+  SF: {
+    name: '49ers',
+    abbreviation: 'SF',
+    primary: '#AA0000',
+    accent: '#B3995D',
+    secondary: '#5E0000',
+  },
+  SEA: {
+    name: 'Seahawks',
+    abbreviation: 'SEA',
+    primary: '#002244',
+    accent: '#69BE28',
+    secondary: '#001122',
+  },
+  ARI: {
+    name: 'Cardinals',
+    abbreviation: 'ARI',
+    primary: '#97233F',
+    accent: '#FFB612',
+    secondary: '#4D1028',
+  },
+  LAR: {
+    name: 'Rams',
+    abbreviation: 'LAR',
+    primary: '#003594',
+    accent: '#FFD100',
+    secondary: '#001A4A',
+  },
+
+  // NFC North
+  CHI: {
+    name: 'Bears',
+    abbreviation: 'CHI',
+    primary: '#0B162A',
+    accent: '#C83803',
+    secondary: '#050B15',
+  },
+  DET: {
+    name: 'Lions',
+    abbreviation: 'DET',
+    primary: '#0076B6',
+    accent: '#B0B7BC',
+    secondary: '#003B5B',
+  },
+  GB: {
+    name: 'Packers',
+    abbreviation: 'GB',
+    primary: '#203731',
+    accent: '#FFB612',
+    secondary: '#101B18',
+  },
+  MIN: {
+    name: 'Vikings',
+    abbreviation: 'MIN',
+    primary: '#4F2683',
+    accent: '#FFC62F',
+    secondary: '#281342',
+  },
+
+  // NFC East
+  DAL: {
+    name: 'Cowboys',
+    abbreviation: 'DAL',
+    primary: '#002244',
+    accent: '#B0B7BC',
+    secondary: '#001122',
+  },
+  PHI: {
+    name: 'Eagles',
+    abbreviation: 'PHI',
+    primary: '#004C54',
+    accent: '#A5ACAF',
+    secondary: '#00262A',
+  },
+  NYG: {
+    name: 'Giants',
+    abbreviation: 'NYG',
+    primary: '#0B2265',
+    accent: '#A71930',
+    secondary: '#051133',
+  },
+  WAS: {
+    name: 'Commanders',
+    abbreviation: 'WAS',
+    primary: '#5A1414',
+    accent: '#FFB612',
+    secondary: '#2D0A0A',
+  },
+
+  // NFC South
+  ATL: {
+    name: 'Falcons',
+    abbreviation: 'ATL',
+    primary: '#A71930',
+    accent: '#A5ACAF',
+    secondary: '#540C18',
+  },
+  CAR: {
+    name: 'Panthers',
+    abbreviation: 'CAR',
+    primary: '#0085CA',
+    accent: '#101820',
+    secondary: '#004365',
+  },
+  NO: {
+    name: 'Saints',
+    abbreviation: 'NO',
+    primary: '#101820',
+    accent: '#D3BC8D',
+    secondary: '#080C10',
+  },
+  TB: {
+    name: 'Buccaneers',
+    abbreviation: 'TB',
+    primary: '#D50A0A',
+    accent: '#34302B',
+    secondary: '#6A0505',
+  },
+
+  // AFC West
+  KC: {
+    name: 'Chiefs',
+    abbreviation: 'KC',
+    primary: '#E31837',
+    accent: '#FFB612',
+    secondary: '#720C1C',
+  },
+  LV: {
+    name: 'Raiders',
+    abbreviation: 'LV',
+    primary: '#000000',
+    accent: '#A5ACAF',
+    secondary: '#1A1A1A',
+  },
+  DEN: {
+    name: 'Broncos',
+    abbreviation: 'DEN',
+    primary: '#002244',
+    accent: '#FB4F14',
+    secondary: '#001122',
+  },
+  LAC: {
+    name: 'Chargers',
+    abbreviation: 'LAC',
+    primary: '#002A5E',
+    accent: '#FFC20E',
+    secondary: '#00152F',
+  },
+
+  // AFC North
+  BAL: {
+    name: 'Ravens',
+    abbreviation: 'BAL',
+    primary: '#241773',
+    accent: '#9E7C0C',
+    secondary: '#120B3A',
+  },
+  CIN: {
+    name: 'Bengals',
+    abbreviation: 'CIN',
+    primary: '#FB4F14',
+    accent: '#000000',
+    secondary: '#7E280A',
+  },
+  CLE: {
+    name: 'Browns',
+    abbreviation: 'CLE',
+    primary: '#311D00',
+    accent: '#FF3C00',
+    secondary: '#180E00',
+  },
+  PIT: {
+    name: 'Steelers',
+    abbreviation: 'PIT',
+    primary: '#101820',
+    accent: '#FFB612',
+    secondary: '#080C10',
+  },
+
+  // AFC South
+  HOU: {
+    name: 'Texans',
+    abbreviation: 'HOU',
+    primary: '#03202F',
+    accent: '#A71930',
+    secondary: '#011018',
+  },
+  IND: {
+    name: 'Colts',
+    abbreviation: 'IND',
+    primary: '#002C5F',
+    accent: '#A5ACAF',
+    secondary: '#001630',
+  },
+  JAX: {
+    name: 'Jaguars',
+    abbreviation: 'JAX',
+    primary: '#006778',
+    accent: '#D7A22A',
+    secondary: '#00343C',
+  },
+  TEN: {
+    name: 'Titans',
+    abbreviation: 'TEN',
+    primary: '#002244',
+    accent: '#4B92DB',
+    secondary: '#001122',
+  },
+
+  // AFC East
+  BUF: {
+    name: 'Bills',
+    abbreviation: 'BUF',
+    primary: '#00338D',
+    accent: '#C60C30',
+    secondary: '#001A47',
+  },
+  MIA: {
+    name: 'Dolphins',
+    abbreviation: 'MIA',
+    primary: '#008E97',
+    accent: '#FC4C02',
+    secondary: '#00474C',
+  },
+  NE: {
+    name: 'Patriots',
+    abbreviation: 'NE',
+    primary: '#002244',
+    accent: '#C60C30',
+    secondary: '#001122',
+  },
+  NYJ: {
+    name: 'Jets',
+    abbreviation: 'NYJ',
+    primary: '#125740',
+    accent: '#FFFFFF',
+    secondary: '#092B20',
+  },
+}
+
+// Default theme when no team is selected
+export const DEFAULT_THEME: TeamTheme = {
+  name: 'Swantail',
+  abbreviation: 'SWT',
+  primary: '#0A0A0A',
+  accent: '#00FF88',
+  secondary: '#1A1A1A',
+}
+
+/**
+ * Get theme for a team abbreviation
+ */
+export function getTeamTheme(teamAbbr: string): TeamTheme {
+  const normalized = teamAbbr.toUpperCase()
+  return TEAM_THEMES[normalized] || DEFAULT_THEME
+}
+
+/**
+ * Get CSS variables for a theme
+ */
+export function getThemeVars(theme: TeamTheme): Record<string, string> {
+  return {
+    '--terminal-bg': theme.secondary,
+    '--terminal-primary': theme.primary,
+    '--terminal-accent': theme.accent,
+    '--terminal-text': '#E0E0E0',
+    '--terminal-muted': '#808080',
+    '--terminal-success': '#00FF88',
+    '--terminal-warning': '#FFB612',
+    '--terminal-error': '#FF4444',
+  }
+}
+
+/**
+ * Apply theme to document root
+ */
+export function applyTheme(theme: TeamTheme): void {
+  const vars = getThemeVars(theme)
+  const root = document.documentElement
+
+  for (const [key, value] of Object.entries(vars)) {
+    root.style.setProperty(key, value)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start -p 3000"
+    "start": "next start -p 3000",
+    "test": "vitest"
   },
   "dependencies": {
     "@vercel/analytics": "^1.5.0",
@@ -21,9 +22,11 @@
   "devDependencies": {
     "@types/node": "^20.14.9",
     "@types/react": "^18.2.79",
+    "@vitejs/plugin-react": "^5.1.2",
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.39",
     "tailwindcss": "^3.4.10",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "vitest": "^4.0.17"
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,7 +17,16 @@ export default {
         border: '#1f2735',
         accent: '#3a7bfd',
         success: '#22c55e',
-        danger: '#ef4444'
+        danger: '#ef4444',
+        // Terminal theme colors (CSS variable references)
+        'terminal-bg': 'var(--terminal-bg)',
+        'terminal-primary': 'var(--terminal-primary)',
+        'terminal-accent': 'var(--terminal-accent)',
+        'terminal-text': 'var(--terminal-text)',
+        'terminal-muted': 'var(--terminal-muted)',
+        'terminal-success': 'var(--terminal-success)',
+        'terminal-warning': 'var(--terminal-warning)',
+        'terminal-error': 'var(--terminal-error)',
       },
       boxShadow: {
         soft: '0 8px 30px rgba(0,0,0,0.35)'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './'),
+    },
+  },
+})


### PR DESCRIPTION
## Summary
Complete implementation of Swantail Terminal - a web-based CLI interface for sports betting analysis powered by specialized AI agents.

### Features
- **7 Specialized Agents**: EPA, Pressure, Weather, QB, HB, WR, TE
- **3 API Routes**: `/api/terminal/scan`, `/api/terminal/build`, `/api/terminal/bet`
- **Terminal UI**: Command parsing, history, team color theming
- **32 NFL Team Themes**: Dynamic colors per matchup

### Commands
| Command | Action |
|---------|--------|
| `[matchup]` | Scan game (e.g., `SF @ SEA`) |
| `build` | Generate correlated parlays |
| `bet` | Generate prop ladders |
| `theme [team]` | Switch color theme |
| `help` | Show commands |

### Architecture
- Typed Zod schemas with strict validation
- Code-derived confidence calculation
- Provenance hashing for reproducibility
- Per-agent implication allowlists

## Test Plan
- [x] 283 tests passing
- [ ] Visit `/terminal` after deploy
- [ ] Test matchup command: `SF @ SEA`
- [ ] Test theme switching: `theme SEA`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Launches an agent-driven betting workflow with reproducible, validated outputs and a themed web terminal.
> 
> - New APIs: `POST /api/terminal/scan`, `POST /api/terminal/build`, `POST /api/terminal/bet` with provenance hashing, confidence calc, correlation/ladder builders, and GET discovery docs
> - Terminal UI (`/terminal`): command parsing (matchup, build, bet, theme, help), history, team color theming; global CSS vars for terminal theme
> - Strict Zod schemas, per-agent implication allowlists, validator chain (sources, line freshness, immutability), and guardrails
> - Large test suite covering agents, engine (confidence, provenance, validators), schemas (ladder/script), APIs, and UI parsing
> - Docs: high-level terminal design plan; .gitignore tweaks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e20d2df2c6634016dd9f3819844cad2ea8f18ba5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->