### PR TITLE
Build football agent system and Bet Station handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ Swantail is a current-week football Game Script terminal. A user selects a match
 
 Swantail does not validate a user's thesis or claim betting confidence. It turns a selected set of causal assumptions into a structured story with explicit conditions and failure modes. Converting that story into correlated markets belongs to the later Bet Station product.
 
+The terminal exposes ten game-level agents. Player positions are deliberately downstream: QB, RB, WR, and TE are reserved Bet Station market families, while Usage is internal role-allocation logic and high variance is derived from resolved game mechanisms.
+
 ## Product Flow
 
 ```text
 Active-week matchup
   -> Game Agents (implicit hypothesis)
-  -> Scenario assumptions
+  -> Matchup-specific Agent Findings
   -> Suggested and user-confirmed anchors
   -> Game Script
   -> Bet Station (deferred)
@@ -21,9 +23,10 @@ Active-week matchup
 - `POST /api/terminal/scenario` accepts a current-week `game_id` and selected Game Agents, then reads the latest stored snapshot when configured.
 - `POST /api/terminal/script` accepts a resolved scenario and compatible outcome anchors.
 - `GET /api/cron/ingest` is the secured scheduled boundary for provider imports and immutable snapshots.
+- `lib/bet-station/contracts.ts` defines the lineage-preserving handoff and reserved position families without adding betting behavior to the terminal.
 - The terminal has no free-text hypothesis, odds paste, output mode, future-week navigation, or parlay builder.
 
-Game Agent output is labeled by evidence state. Without a stored snapshot it remains `scenario_assumptions`; with sourced data it can report observed context, support, conflict, stale data, or missing data. The script endpoint uses OpenAI when configured and a deterministic fallback otherwise.
+Game Agent output includes a matchup headline, materiality state, decisive signals, caveats, and evidence lineage. Rest/Travel is derived directly from the stored schedule even before Postgres is configured. Remote provider data remains snapshot-bound. The script endpoint uses OpenAI when configured and a deterministic fallback otherwise.
 
 ## Local Development
 
@@ -57,5 +60,6 @@ npm run build
 ```
 
 The active product contract is documented in [`docs/PRODUCT_CONTRACT.md`](docs/PRODUCT_CONTRACT.md). The data and product sequence is in [`docs/ROADMAP.md`](docs/ROADMAP.md).
+The football-native agent blueprint and individual specialist specs are in [`docs/agents/README.md`](docs/agents/README.md).
 Provider status, setup, and owner decisions are in [`docs/DATA_FOUNDATION.md`](docs/DATA_FOUNDATION.md).
 The proposed initial market scope and responsible-gaming gate are in [`docs/BET_STATION_GUARDRAILS.md`](docs/BET_STATION_GUARDRAILS.md).

--- a/__tests__/api/terminal/scenario.test.ts
+++ b/__tests__/api/terminal/scenario.test.ts
@@ -25,4 +25,22 @@ describe('/api/terminal/scenario', () => {
     expect(body.scenario.events).toHaveLength(2)
     expect(body.scenario.evidence_state).toBe('scenario_assumptions')
   })
+
+  it('rejects retired player-position selectors', async () => {
+    const game = loadSchedule().games[0]
+    const response = await POST(request({ game_id: game.game_id, agent_ids: ['wr'] }))
+
+    expect(response.status).toBe(400)
+  })
+
+  it('derives Rest context without requiring a stored snapshot', async () => {
+    const game = loadSchedule().games[0]
+    const response = await POST(request({ game_id: game.game_id, agent_ids: ['rest'] }))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.scenario.events[0].finding.state).toBe('contextual')
+    expect(body.scenario.events[0].evidence_state).toBe('observed_context')
+    expect(body.scenario.events[0].observations).toHaveLength(2)
+  })
 })

--- a/__tests__/data/providers.test.ts
+++ b/__tests__/data/providers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
-import { nflverseEpaProvider, nflverseInjuryProvider } from '@/lib/data/providers/nflverse'
+import { nflverseInjuryProvider, nflverseTeamStatsProvider } from '@/lib/data/providers/nflverse'
 import { nwsWeatherProvider, parseWindMph } from '@/lib/data/providers/nws'
+import { scheduleRestProvider } from '@/lib/data/providers/rest'
 import { loadSchedule } from '@/lib/nfl/schedule'
 
 const game = loadSchedule({ season: 2026, week: 1 }).games[0]
@@ -64,18 +65,29 @@ describe('observation providers', () => {
     expect(result.game_states[game.game_id].state).toBe('available')
   })
 
-  it('creates a two-team offensive EPA baseline for week one', async () => {
+  it('creates shared efficiency, turnover, and trenches baselines for week one', async () => {
     const csv = [
-      'season,team,season_type,games,attempts,carries,sacks_suffered,passing_epa,rushing_epa',
-      '2025,NE,REG,17,600,400,40,20,10',
-      '2025,SEA,REG,17,550,450,30,80,20',
+      'season,week,team,season_type,attempts,carries,sacks_suffered,passing_epa,rushing_epa,passing_interceptions,fumbles_lost_total,def_interceptions,fumble_recovery_opp,def_fumbles_forced,def_sacks,def_qb_hits,def_tackles_for_loss',
+      '2025,1,NE,REG,35,20,5,-4,-2,2,1,0,0,0,1,2,2',
+      '2025,1,SEA,REG,30,28,1,8,4,0,0,2,1,2,4,7,6',
     ].join('\n')
     const fetcher = vi.fn(async () => new Response(csv, { status: 200 })) as unknown as typeof fetch
 
-    const result = await nflverseEpaProvider.collect(context(fetcher))
+    const result = await nflverseTeamStatsProvider.collect(context(fetcher))
+
+    expect(result.observations).toHaveLength(6)
+    expect(result.game_states[game.game_id].state).toBe('available')
+    expect(new Set(result.observations.map(item => item.agent_id))).toEqual(new Set(['epa', 'turnovers', 'trenches']))
+    expect(result.observations.map(item => item.subject.id)).toEqual(expect.arrayContaining(['NE', 'SEA']))
+  })
+
+  it('derives Week 1 rest and travel context without inventing prior-game rest', async () => {
+    const result = await scheduleRestProvider.collect(context(fetch))
+    const values = result.observations.map(observation => observation.value as Record<string, unknown>)
 
     expect(result.observations).toHaveLength(2)
-    expect(result.game_states[game.game_id].state).toBe('available')
-    expect(result.observations.map(item => item.subject.id)).toEqual(expect.arrayContaining(['NE', 'SEA']))
+    expect(result.observations.every(observation => observation.source.quality === 'internal')).toBe(true)
+    expect(values.every(value => value.schedule_spot === 'opening_week')).toBe(true)
+    expect(values.every(value => value.turnaround_days === null)).toBe(true)
   })
 })

--- a/__tests__/nfl/game.test.ts
+++ b/__tests__/nfl/game.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { GameSnapshotSchema } from '@/lib/data/contracts'
+import { GameSnapshotSchema, OBSERVATION_AGENT_IDS } from '@/lib/data/contracts'
 import { createGameId } from '@/lib/nfl/game'
 
 describe('canonical NFL game contracts', () => {
@@ -28,7 +28,7 @@ describe('canonical NFL game contracts', () => {
         display: 'New England Patriots @ Seattle Seahawks',
       },
       observations: [],
-      availability: Object.fromEntries(['weather', 'injury', 'epa'].map(agent => [agent, {
+      availability: Object.fromEntries(OBSERVATION_AGENT_IDS.map(agent => [agent, {
         state: 'missing',
         checked_at: '2026-02-08T18:00:00Z',
         observation_count: 0,
@@ -55,7 +55,7 @@ describe('canonical NFL game contracts', () => {
         display: 'New England Patriots @ Seattle Seahawks',
       },
       observations: [],
-      availability: Object.fromEntries(['weather', 'injury', 'epa'].map(agent => [agent, {
+      availability: Object.fromEntries(OBSERVATION_AGENT_IDS.map(agent => [agent, {
         state: 'missing',
         checked_at: '2026-02-08T18:00:00Z',
         observation_count: 0,

--- a/__tests__/terminal/agent-catalog.test.ts
+++ b/__tests__/terminal/agent-catalog.test.ts
@@ -1,0 +1,64 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  BET_STATION_HANDOFF_VERSION,
+  BET_STATION_INTERNAL_LENSES,
+  BET_STATION_POSITION_CATALOG,
+  BET_STATION_POSITION_IDS,
+  BetStationHandoffSchema,
+} from '@/lib/bet-station/contracts'
+import { ObservationAgentIdSchema } from '@/lib/data/contracts'
+import {
+  GAME_AGENT_CATALOG,
+  GAME_AGENT_IDS,
+  TERMINAL_CONTRACT_VERSION,
+} from '@/lib/terminal/contracts'
+
+describe('game agent catalog', () => {
+  it('has one documented specification for every selectable agent', () => {
+    for (const agentId of GAME_AGENT_IDS) {
+      const entry = GAME_AGENT_CATALOG[agentId]
+      const absolutePath = join(process.cwd(), entry.specPath)
+
+      expect(entry.question.length).toBeGreaterThan(20)
+      expect(entry.description.length).toBeGreaterThan(40)
+      expect(existsSync(absolutePath), `${agentId} spec is missing`).toBe(true)
+      const specification = readFileSync(absolutePath, 'utf8')
+      expect(specification).toContain(`agent_id: ${agentId}`)
+      expect(specification).toContain('## Scope Boundary')
+    }
+  })
+
+  it('only labels agents with observation adapters as pilot-observed', () => {
+    for (const agentId of GAME_AGENT_IDS) {
+      const hasObservationContract = ObservationAgentIdSchema.safeParse(agentId).success
+      expect(GAME_AGENT_CATALOG[agentId].dataSupport === 'pilot_observations').toBe(hasObservationContract)
+    }
+  })
+
+  it('keeps player-market choices outside the Game Story catalog', () => {
+    expect(GAME_AGENT_IDS).toHaveLength(10)
+    expect(GAME_AGENT_IDS).not.toEqual(expect.arrayContaining(['hb', 'wr', 'te', 'usage', 'volatility']))
+    expect(BET_STATION_POSITION_IDS).toEqual(['qb', 'rb', 'wr', 'te'])
+    expect(Object.keys(BET_STATION_POSITION_CATALOG)).toEqual(BET_STATION_POSITION_IDS)
+    expect(BET_STATION_INTERNAL_LENSES).toEqual(['usage'])
+    const positionIds = new Set<string>(BET_STATION_POSITION_IDS)
+    expect(GAME_AGENT_IDS.filter(id => positionIds.has(id))).toEqual(['qb'])
+  })
+
+  it('preserves Game Script lineage in the future Bet Station handoff', () => {
+    const handoff = BetStationHandoffSchema.parse({
+      contract_version: BET_STATION_HANDOFF_VERSION,
+      source_contract_version: TERMINAL_CONTRACT_VERSION,
+      script_id: 'script_1',
+      scenario_id: 'scenario_1',
+      scenario_revision_id: 'scenario_revision_1',
+      snapshot_id: 'snapshot_1',
+      game_id: 'game_1',
+      anchor_ids: ['game_under', 'grind'],
+    })
+
+    expect(handoff.source_contract_version).toBe('game-script-v5')
+  })
+})

--- a/__tests__/terminal/data-backed-agents.test.ts
+++ b/__tests__/terminal/data-backed-agents.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  GameSnapshotSchema,
+  OBSERVATION_AGENT_IDS,
+  type IngestionFeedResult,
+} from '@/lib/data/contracts'
+import { nflverseTeamStatsProvider } from '@/lib/data/providers/nflverse'
+import { scheduleRestProvider } from '@/lib/data/providers/rest'
+import { loadSchedule, type ScheduleGame } from '@/lib/nfl/schedule'
+import type { ScenarioGame } from '@/lib/terminal/contracts'
+import { resolveScenario } from '@/lib/terminal/scenario'
+
+function providerContext(game: ScheduleGame, now: Date, fetcher: typeof fetch = fetch) {
+  return {
+    games: [game],
+    season: game.season,
+    week: game.week,
+    now,
+    fetch: fetcher,
+  }
+}
+
+function scenarioGame(game: ScheduleGame): ScenarioGame {
+  return {
+    game_id: game.game_id,
+    season: game.season,
+    week: game.week,
+    away_team: game.away_team,
+    home_team: game.home_team,
+    kickoff: game.kickoff,
+    display: game.display,
+    time: game.time,
+  }
+}
+
+function snapshotFromFeed(params: {
+  game: ScheduleGame
+  feed: IngestionFeedResult
+  capturedAt: string
+}) {
+  const availability = Object.fromEntries(OBSERVATION_AGENT_IDS.map(agentId => {
+    const observations = params.feed.observations.filter(observation => observation.agent_id === agentId)
+    return [agentId, observations.length
+      ? {
+          state: 'available',
+          checked_at: params.feed.checked_at,
+          observation_count: observations.length,
+        }
+      : {
+          state: 'missing',
+          checked_at: params.feed.checked_at,
+          observation_count: 0,
+        }]
+  }))
+  return GameSnapshotSchema.parse({
+    snapshot_id: `snapshot_${params.game.game_id}`,
+    game_id: params.game.game_id,
+    captured_at: params.capturedAt,
+    contract_version: 'observation-v1',
+    game: params.game,
+    observations: params.feed.observations,
+    availability,
+    content_hash: 'b'.repeat(64),
+  })
+}
+
+describe('data-backed Game Agent findings', () => {
+  it('cross-matches turnover and trenches profiles into material findings', async () => {
+    const game = loadSchedule({ season: 2026, week: 1 }).games[0]
+    const csv = [
+      'season,week,team,season_type,attempts,carries,sacks_suffered,passing_epa,rushing_epa,passing_interceptions,fumbles_lost_total,def_interceptions,fumble_recovery_opp,def_fumbles_forced,def_sacks,def_qb_hits,def_tackles_for_loss',
+      '2025,1,NE,REG,35,20,5,-4,-2,2,1,0,0,0,1,2,2',
+      '2025,1,SEA,REG,30,28,1,8,4,0,0,2,1,2,4,7,6',
+    ].join('\n')
+    const fetcher = vi.fn(async () => new Response(csv, { status: 200 })) as unknown as typeof fetch
+    const now = new Date('2026-08-15T12:00:00.000Z')
+    const feed = await nflverseTeamStatsProvider.collect(providerContext(game, now, fetcher))
+    const snapshot = snapshotFromFeed({ game, feed, capturedAt: now.toISOString() })
+    const scenario = resolveScenario({
+      game: scenarioGame(game),
+      agentIds: ['trenches', 'turnovers'],
+      snapshot,
+      now,
+    })
+
+    expect(scenario.events.map(event => event.finding.state)).toEqual(['material', 'material'])
+    expect(scenario.events.map(event => event.finding.direction)).toEqual(['home', 'home'])
+    expect(scenario.events[0].finding.caveats.join(' ')).toContain('proxy')
+    expect(scenario.events[1].finding.signals.map(signal => signal.label)).toContain('Cross-match exposure')
+    expect(scenario.suggested_anchor_ids).toEqual(['home_win', 'high_variance', 'run_heavy'])
+  })
+
+  it('turns a real schedule gap into a directional Rest finding', async () => {
+    const game = loadSchedule({ season: 2026, week: 2 }).games.find(candidate => (
+      candidate.away_team === 'PIT' && candidate.home_team === 'NE'
+    ))!
+    const now = new Date('2026-09-16T12:00:00.000Z')
+    const feed = await scheduleRestProvider.collect(providerContext(game, now))
+    const snapshot = snapshotFromFeed({ game, feed, capturedAt: now.toISOString() })
+    const scenario = resolveScenario({
+      game: scenarioGame(game),
+      agentIds: ['rest'],
+      snapshot,
+      now,
+    })
+    const finding = scenario.events[0].finding
+
+    expect(finding.state).toBe('material')
+    expect(finding.direction).toBe('home')
+    expect(finding.headline).toContain('NE')
+    expect(finding.signals.find(signal => signal.label === 'Turnaround')).toMatchObject({
+      away_value: '7 days',
+      home_value: '10.7 days',
+    })
+    expect(scenario.suggested_anchor_ids).toEqual(['home_win'])
+  })
+})

--- a/__tests__/terminal/scenario.test.ts
+++ b/__tests__/terminal/scenario.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from 'vitest'
+import { createBetStationHandoff } from '@/lib/bet-station/contracts'
 import { GameSnapshotSchema } from '@/lib/data/contracts'
-import { ScenarioResolutionSchema, type ScenarioGame } from '@/lib/terminal/contracts'
+import {
+  GAME_AGENT_IDS,
+  GameScriptSchema,
+  ScenarioResolutionSchema,
+  type ScenarioGame,
+} from '@/lib/terminal/contracts'
 import { resolveScenario } from '@/lib/terminal/scenario'
+import { createDeterministicDraft, finalizeScript } from '@/lib/terminal/script'
 
 const GAME: ScenarioGame = {
   game_id: '2026-wk01-NE-at-SEA',
@@ -34,7 +41,43 @@ describe('scenario contract', () => {
 
     expect(scenario.suggested_anchor_ids).toContain('game_under')
     expect(scenario.suggested_anchor_ids).not.toContain('game_over')
-    expect(scenario.suggested_anchor_ids.filter(id => ['shootout', 'grind', 'blowout'].includes(id))).toHaveLength(1)
+    expect(scenario.suggested_anchor_ids.filter(id => ['shootout', 'grind', 'blowout', 'high_variance'].includes(id))).toHaveLength(1)
+  })
+
+  it('resolves the expanded football-native lenses as explicit assumptions', () => {
+    const agentIds = ['momentum', 'trenches', 'turnovers', 'qb', 'rest'] as const
+    const scenario = resolveScenario({ game: GAME, agentIds: [...agentIds] })
+
+    expect(scenario.selected_agent_ids).toEqual(agentIds)
+    expect(scenario.events.map(event => event.agent_id)).toEqual(agentIds)
+    expect(scenario.events.every(event => event.evidence_state === 'assumption_only')).toBe(true)
+    expect(scenario.suggested_anchor_ids).toEqual(['game_over', 'grind', 'run_heavy'])
+  })
+
+  it('derives a high-variance shape from a turnover finding without a volatility agent', () => {
+    const scenario = resolveScenario({ game: GAME, agentIds: ['turnovers'] })
+
+    expect(scenario.suggested_anchor_ids).toEqual(['high_variance'])
+  })
+
+  it('can synthesize every selectable agent without exceeding the script contract', () => {
+    const scenario = resolveScenario({ game: GAME, agentIds: [...GAME_AGENT_IDS] })
+    const anchorIds = scenario.suggested_anchor_ids
+    const script = finalizeScript({
+      scenario,
+      anchorIds,
+      draft: createDeterministicDraft(scenario, anchorIds),
+      generation: 'deterministic',
+      modelId: 'deterministic-v1',
+    })
+
+    expect(script.causal_chain).toHaveLength(GAME_AGENT_IDS.length + 1)
+    expect(GameScriptSchema.safeParse(script).success).toBe(true)
+    expect(createBetStationHandoff({ scenario, script })).toMatchObject({
+      script_id: script.script_id,
+      scenario_revision_id: scenario.scenario_revision_id,
+      game_id: GAME.game_id,
+    })
   })
 
   it('binds sourced observations to a stable scenario revision', () => {
@@ -78,6 +121,9 @@ describe('scenario contract', () => {
         weather: { state: 'available', checked_at: '2026-09-09T12:00:00.000Z', observation_count: 1 },
         injury: { state: 'missing', checked_at: '2026-09-09T12:00:00.000Z', observation_count: 0 },
         epa: { state: 'missing', checked_at: '2026-09-09T12:00:00.000Z', observation_count: 0 },
+        trenches: { state: 'missing', checked_at: '2026-09-09T12:00:00.000Z', observation_count: 0 },
+        turnovers: { state: 'missing', checked_at: '2026-09-09T12:00:00.000Z', observation_count: 0 },
+        rest: { state: 'missing', checked_at: '2026-09-09T12:00:00.000Z', observation_count: 0 },
       },
       content_hash: 'a'.repeat(64),
     })
@@ -92,6 +138,7 @@ describe('scenario contract', () => {
     expect(scenario.scenario_revision_id).toMatch(/^scenario_revision_/)
     expect(scenario.evidence_state).toBe('observations_available')
     expect(scenario.events[0].evidence_state).toBe('observed_support')
+    expect(scenario.events[0].finding.state).toBe('material')
     expect(scenario.events[0].observations[0].source.provider).toBe('nws')
   })
 })

--- a/app/api/terminal/scenario/route.ts
+++ b/app/api/terminal/scenario/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { loadLatestGameSnapshot, persistScenario } from '@/lib/data/repository'
+import { attachScheduleRestSnapshot } from '@/lib/data/providers/rest'
 import { loadOperationalSchedule, ScheduleNotFoundError } from '@/lib/nfl/schedule'
 import { ScenarioRequestSchema, type ScenarioGame } from '@/lib/terminal/contracts'
 import { resolveScenario } from '@/lib/terminal/scenario'
@@ -43,7 +44,10 @@ export async function POST(request: Request) {
       time: scheduledGame.time,
     }
     const agentIds = [...new Set(parsed.data.agent_ids)]
-    const snapshot = await loadLatestGameSnapshot(game.game_id)
+    let snapshot = await loadLatestGameSnapshot(game.game_id)
+    if (agentIds.includes('rest') && !snapshot?.observations.some(observation => observation.agent_id === 'rest')) {
+      snapshot = await attachScheduleRestSnapshot({ game: scheduledGame, snapshot })
+    }
     const scenario = resolveScenario({ game, agentIds, snapshot })
     const persistence = await persistScenario(scenario)
 

--- a/app/api/terminal/script/route.ts
+++ b/app/api/terminal/script/route.ts
@@ -47,6 +47,7 @@ function buildPrompt(scenario: ScenarioResolution, anchorIds: ScenarioAnchorId[]
       label: event.label,
       assumption: event.assumption,
       resolved_statement: event.statement,
+      finding: event.finding,
       evidence_state: event.evidence_state,
       observations: event.observations.map(observation => ({
         metric: observation.metric,

--- a/components/SwantailTerminalPanel.tsx
+++ b/components/SwantailTerminalPanel.tsx
@@ -1,25 +1,29 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import type { LucideIcon } from 'lucide-react'
 import {
-  Activity,
   ChartNoAxesCombined,
   Check,
   CloudSun,
   Crosshair,
   Gauge,
   HeartPulse,
+  Info,
   LoaderCircle,
+  Moon,
   Play,
-  RadioTower,
-  Route,
-  ScanSearch,
+  RefreshCcw,
+  Shield,
   Sparkles,
   TimerReset,
+  TrendingUp,
+  X,
 } from 'lucide-react'
 import {
   GAME_AGENT_CATALOG,
   GAME_AGENT_IDS,
+  TERMINAL_CONTRACT_VERSION,
   type GameAgentId,
   type ScenarioAnchorId,
   type ScenarioGame,
@@ -36,15 +40,15 @@ type ScheduleSummary = {
 }
 const AGENT_ICONS: Record<GameAgentId, LucideIcon> = {
   weather: CloudSun,
-  pressure: Gauge,
+  momentum: TrendingUp,
   pace: TimerReset,
   injury: HeartPulse,
   epa: ChartNoAxesCombined,
+  pressure: Gauge,
+  trenches: Shield,
+  turnovers: RefreshCcw,
   qb: Crosshair,
-  hb: Route,
-  wr: RadioTower,
-  te: Activity,
-  usage: ScanSearch,
+  rest: Moon,
 }
 
 const ANCHOR_CATEGORY_LABELS = {
@@ -54,6 +58,15 @@ const ANCHOR_CATEGORY_LABELS = {
   shape: 'Shape',
   style: 'Style',
 } as const
+
+const FINDING_STYLES = {
+  material: 'border-amber-200/30 bg-amber-200/10 text-amber-100',
+  contextual: 'border-cyan-200/25 bg-cyan-200/10 text-cyan-100',
+  balanced: 'border-emerald-200/25 bg-emerald-200/10 text-emerald-100',
+  unavailable: 'border-white/10 bg-white/5 text-white/45',
+} as const
+
+const AGENT_GUIDE_STORAGE_KEY = 'swantail:agent-guide'
 
 type Props = {
   schedule: ScheduleSummary | null
@@ -90,6 +103,31 @@ export default function SwantailTerminalPanel({
   onAnchorToggle,
   onGenerateScript,
 }: Props) {
+  const [agentGuideEnabled, setAgentGuideEnabled] = useState(true)
+  const [infoAgentId, setInfoAgentId] = useState<GameAgentId | null>(null)
+
+  useEffect(() => {
+    try {
+      setAgentGuideEnabled(window.localStorage.getItem(AGENT_GUIDE_STORAGE_KEY) !== 'off')
+    } catch {
+      // Keep guidance enabled when storage is unavailable.
+    }
+  }, [])
+
+  const toggleAgentGuide = () => {
+    setAgentGuideEnabled(current => {
+      const next = !current
+      try {
+        window.localStorage.setItem(AGENT_GUIDE_STORAGE_KEY, next ? 'on' : 'off')
+      } catch {
+        // The preference can remain session-only when storage is unavailable.
+      }
+      if (!next) setInfoAgentId(null)
+      return next
+    })
+  }
+
+  const infoAgent = infoAgentId ? GAME_AGENT_CATALOG[infoAgentId] : null
   const categories = scenario
     ? Object.entries(ANCHOR_CATEGORY_LABELS).map(([category, label]) => ({
         category,
@@ -103,7 +141,7 @@ export default function SwantailTerminalPanel({
       <div className="flex items-center justify-between border-b border-white/10 bg-[#151816] px-4 py-3">
         <div className="flex items-center gap-2 font-mono text-xs uppercase text-white/65">
           <span className="h-2 w-2 rounded-full bg-emerald-300" />
-          Terminal contract 2.0
+          {TERMINAL_CONTRACT_VERSION}
         </div>
         <span className="font-mono text-[11px] text-white/35">CURRENT WEEK ONLY</span>
       </div>
@@ -137,31 +175,112 @@ export default function SwantailTerminalPanel({
           <span className="font-mono text-[11px] text-emerald-200/70">{selectedAgentIds.length} selected</span>
         </div>
         <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
-          {GAME_AGENT_IDS.map(agentId => {
+          {GAME_AGENT_IDS.map((agentId, index) => {
             const agent = GAME_AGENT_CATALOG[agentId]
             const Icon = AGENT_ICONS[agentId]
             const selected = selectedAgentIds.includes(agentId)
+            const tooltipAlignment = index % 5 === 0
+              ? 'left-0'
+              : index % 5 === 4
+                ? 'right-0'
+                : 'left-1/2 -translate-x-1/2'
             return (
-              <button
+              <div
                 key={agentId}
-                type="button"
-                aria-pressed={selected}
-                title={agent.description}
-                onClick={() => onAgentToggle(agentId)}
-                className={`min-h-[76px] rounded-md border p-2.5 text-left transition focus:outline-none focus:ring-2 focus:ring-emerald-300/30 ${
+                className={`group relative min-h-[76px] rounded-md border transition focus-within:ring-2 focus-within:ring-emerald-300/30 ${
                   selected
                     ? 'border-emerald-300/45 bg-emerald-300/10 text-white'
                     : 'border-white/10 bg-black/15 text-white/55 hover:border-white/20 hover:text-white/80'
                 }`}
               >
-                <div className="flex items-center justify-between">
-                  <Icon className={`h-4 w-4 ${selected ? 'text-emerald-200' : 'text-white/35'}`} aria-hidden />
-                  {selected && <Check className="h-3.5 w-3.5 text-emerald-200" aria-hidden />}
-                </div>
-                <div className="mt-3 text-xs font-medium">{agent.label}</div>
-              </button>
+                <button
+                  type="button"
+                  aria-pressed={selected}
+                  aria-describedby={agentGuideEnabled ? `agent-tooltip-${agentId}` : undefined}
+                  onClick={() => onAgentToggle(agentId)}
+                  className="min-h-[74px] w-full rounded-md p-2.5 text-left focus:outline-none"
+                >
+                  <div className="flex items-center justify-between pr-7">
+                    <Icon className={`h-4 w-4 ${selected ? 'text-emerald-200' : 'text-white/35'}`} aria-hidden />
+                    {selected && <Check className="h-3.5 w-3.5 text-emerald-200" aria-hidden />}
+                  </div>
+                  <div className="mt-3 text-xs font-medium">{agent.label}</div>
+                </button>
+
+                {agentGuideEnabled && (
+                  <>
+                    <button
+                      type="button"
+                      aria-label={`About ${agent.label}`}
+                      aria-expanded={infoAgentId === agentId}
+                      aria-controls="agent-guide-detail"
+                      onClick={() => setInfoAgentId(current => current === agentId ? null : agentId)}
+                      className="absolute right-1.5 top-1.5 z-10 inline-flex h-7 w-7 items-center justify-center rounded-full text-white/40 transition hover:bg-white/10 hover:text-white focus:bg-white/10 focus:text-white focus:outline-none focus:ring-2 focus:ring-cyan-200/30 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
+                    >
+                      <Info className="h-3.5 w-3.5" aria-hidden />
+                    </button>
+                    <div
+                      id={`agent-tooltip-${agentId}`}
+                      role="tooltip"
+                      className={`invisible absolute top-[calc(100%+8px)] z-30 hidden w-64 rounded-md border border-white/15 bg-[#171a18] p-3 text-left opacity-0 shadow-xl transition sm:block sm:group-hover:visible sm:group-hover:opacity-100 sm:group-focus-within:visible sm:group-focus-within:opacity-100 ${tooltipAlignment}`}
+                    >
+                      <div className="text-xs font-semibold leading-5 text-white">{agent.question}</div>
+                      <p className="mt-1 text-[11px] leading-4 text-white/60">{agent.description}</p>
+                      <div className="mt-2 font-mono text-[9px] uppercase text-cyan-200/55">
+                        {agent.dataSupport === 'pilot_observations' ? 'Sourced context available' : 'Scenario framing lens'}
+                      </div>
+                    </div>
+                  </>
+                )}
+              </div>
             )
           })}
+        </div>
+
+        {agentGuideEnabled && infoAgent && (
+          <div id="agent-guide-detail" role="region" aria-live="polite" className="mt-3 border-l-2 border-cyan-200/45 bg-cyan-200/[0.06] px-3 py-2.5">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <div className="font-mono text-[10px] uppercase text-cyan-100/65">{infoAgent.label} agent</div>
+                <div className="mt-1 text-sm font-medium leading-5 text-white/90">{infoAgent.question}</div>
+              </div>
+              <button
+                type="button"
+                aria-label="Close agent information"
+                onClick={() => setInfoAgentId(null)}
+                className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-white/40 transition hover:bg-white/10 hover:text-white focus:outline-none focus:ring-2 focus:ring-cyan-200/30"
+              >
+                <X className="h-3.5 w-3.5" aria-hidden />
+              </button>
+            </div>
+            <p className="mt-1 text-xs leading-5 text-white/55">{infoAgent.description}</p>
+            <div className="mt-2 font-mono text-[9px] uppercase text-cyan-200/50">
+              {infoAgent.dataSupport === 'pilot_observations' ? 'Sourced context available' : 'Scenario framing lens'}
+            </div>
+          </div>
+        )}
+
+        <div className="mt-3 flex items-center justify-between border-t border-white/10 pt-3">
+          <div>
+            <div className="text-xs font-medium text-white/70">Agent guide</div>
+            <div className="mt-0.5 text-[10px] text-white/35">Descriptions and data status</div>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={agentGuideEnabled}
+            aria-label="Show agent guidance"
+            onClick={toggleAgentGuide}
+            className={`relative h-5 w-9 rounded-full border transition focus:outline-none focus:ring-2 focus:ring-emerald-300/30 ${
+              agentGuideEnabled ? 'border-emerald-300/45 bg-emerald-300/25' : 'border-white/15 bg-white/5'
+            }`}
+          >
+            <span
+              className={`absolute top-0.5 h-3.5 w-3.5 rounded-full transition ${
+                agentGuideEnabled ? 'left-[18px] bg-emerald-200' : 'left-0.5 bg-white/45'
+              }`}
+            />
+          </button>
         </div>
         <button
           type="button"
@@ -181,16 +300,54 @@ export default function SwantailTerminalPanel({
         {schedule && <div className="text-cyan-200/75">schedule  {schedule.seasonLabel ?? schedule.season} week {schedule.week} ready</div>}
         {selectedGame && <div className="text-white/65">matchup   {selectedGame.display}</div>}
         <div className="text-white/65">agents    {selectedAgentIds.length ? selectedAgentIds.join(' + ') : 'none'}</div>
-        {scenarioLoading && <div className="text-amber-200/80">dispatch  resolving selected assumptions...</div>}
-        {scenario?.events.map(event => (
-          <div key={event.id} className="grid grid-cols-[72px_1fr] gap-2">
-            <span className="text-emerald-200/70">{event.agent_id}</span>
-            <span className="text-white/75">
-              {event.statement}
-              <span className="ml-2 text-[10px] uppercase text-white/30">[{event.evidence_state.replace(/_/g, ' ')}]</span>
-            </span>
-          </div>
-        ))}
+        {scenarioLoading && <div className="text-amber-200/80">dispatch  analyzing matchup data...</div>}
+        {scenario?.events.map(event => {
+          const providers = [...new Set(event.observations.map(observation => observation.source.provider))]
+          const observedAt = event.observations
+            .map(observation => Date.parse(observation.observed_at))
+            .filter(Number.isFinite)
+            .sort((left, right) => right - left)[0]
+          return (
+            <article key={event.id} className="border-b border-white/10 py-4 last:border-b-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-[11px] font-semibold uppercase text-emerald-200/80">{event.label}</span>
+                <span className={`rounded border px-1.5 py-0.5 text-[9px] uppercase leading-none ${FINDING_STYLES[event.finding.state]}`}>
+                  {event.finding.state}
+                </span>
+                {event.finding.direction !== 'none' && (
+                  <span className="text-[10px] uppercase text-white/35">
+                    {event.finding.direction === 'away' ? selectedGame?.away_team : selectedGame?.home_team} path
+                  </span>
+                )}
+              </div>
+              <h3 className="mt-1.5 font-sans text-sm font-medium leading-5 text-white/90">{event.finding.headline}</h3>
+              <p className="mt-1 font-sans text-xs leading-5 text-white/55">{event.finding.detail}</p>
+              {event.finding.signals.length > 0 && (
+                <div className="mt-3 grid gap-x-4 gap-y-2 sm:grid-cols-3">
+                  {event.finding.signals.slice(0, 3).map(signal => (
+                    <div key={signal.label} className="min-w-0 border-l border-white/10 pl-2.5">
+                      <div className="text-[9px] uppercase text-white/30">{signal.label}</div>
+                      {signal.value && <div className="mt-0.5 break-words text-[11px] leading-4 text-white/70">{signal.value}</div>}
+                      {(signal.away_value || signal.home_value) && (
+                        <div className="mt-0.5 break-words text-[10px] leading-4 text-white/65">
+                          {selectedGame?.away_team} {signal.away_value ?? '-'} <span className="text-white/25">/</span> {selectedGame?.home_team} {signal.home_value ?? '-'}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+              <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-[9px] uppercase text-white/25">
+                <span>{event.evidence_state.replace(/_/g, ' ')}</span>
+                {providers.length > 0 && <span>source {providers.join(' + ')}</span>}
+                {observedAt && <span>as of {new Date(observedAt).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}</span>}
+              </div>
+              {event.finding.caveats[0] && (
+                <p className="mt-1 font-sans text-[10px] leading-4 text-white/30">{event.finding.caveats[0]}</p>
+              )}
+            </article>
+          )
+        })}
         {scenario && (
           <div className="mt-2 text-cyan-200/75">
             scenario  {scenario.events.length} agents / {scenario.evidence_state.replace(/_/g, ' ')} / {scenario.suggested_anchor_ids.length} anchors

--- a/docs/BET_STATION_GUARDRAILS.md
+++ b/docs/BET_STATION_GUARDRAILS.md
@@ -11,6 +11,14 @@ The first Bet Station release should cover only pregame, full-game NFL:
 
 It should exclude moneylines, team totals, player props, parlays, futures, and in-play markets until ingestion, closing-line capture, calibration, and correlation testing are dependable.
 
+## Game Script Handoff
+
+Bet Station begins only after a Game Script is complete. The versioned handoff in `lib/bet-station/contracts.ts` carries the script, scenario revision, snapshot, game, and selected-anchor lineage. It does not place odds, markets, player choices, or recommendations back into the Game Script contract.
+
+Quarterback, Running Back, Wide Receiver, and Tight End are reserved Bet Station position families. They are not selectable Game Agents. Usage remains an internal role-allocation lens used to determine which players have the participation and high-value opportunities needed to express a resolved story.
+
+The first approved release remains spreads and totals only. Position families become user-facing only in a later player-market phase after player identity, participation, role, market, and pricing data meet the same freshness and lineage requirements as game-level recommendations.
+
 Every candidate position must include:
 
 - source book and quote timestamp;

--- a/docs/DATA_FOUNDATION.md
+++ b/docs/DATA_FOUNDATION.md
@@ -9,7 +9,8 @@ The code supports a transparent pilot without treating public research feeds as 
 | Schedule | Versioned 2026 season file | Internal bootstrap | Replace or reconcile with licensed feed |
 | Weather | National Weather Service hourly API | Official | Suitable for US venues; global fallback still required |
 | Injuries | nflverse release data | Research | Pilot only; licensed game-day feed required |
-| Team performance | nflverse team statistics | Research | Suitable for feature research and backtesting |
+| Team performance | nflverse weekly team statistics | Research | Powers Efficiency, Turnovers, and a transparent Trenches proxy for research/backtesting |
+| Rest/Travel | Full-season schedule plus venue geography | Internal derived | Turnaround, schedule spot, road sequence, and travel context available now |
 | Odds | None | Not configured | Required for Bet Station |
 
 The nflverse adapters retain its terms URL on every observation. They should not be promoted to the contractual production source without an explicit licensing review.
@@ -28,7 +29,9 @@ For a public 2026 regular-season product, choose one licensed football provider 
 
 SportsDataIO's self-serve Discovery Lab is useful for development but is next-day delayed and not licensed for commercial redistribution. A season product therefore needs a commercial agreement or an equivalent licensed provider, not merely the $99-$149 hobby tier.
 
-Initial production scope should remain narrow: schedule, rosters, injuries/inactives, weather, team efficiency, spreads, and totals. Player props and live play-by-play should not be part of the first agreement unless the price difference is negligible.
+Initial production scope should remain narrow: schedule, rosters, injuries/inactives, weather, team efficiency, turnover profiles, line/front metrics, spreads, and totals. Player props and live play-by-play should not be part of the first agreement unless the price difference is negligible.
+
+The current Trenches finding is explicitly a result-based proxy built from sack rate allowed, rushing EPA, defensive sacks/QB hits, and tackles for loss. Do not market it as an assignment-level blocking grade. Production-grade Trenches analysis requires licensed pressure, blocking, lineup-continuity, and run-front data.
 
 ## Storage Contract
 
@@ -50,7 +53,7 @@ POSTGRES_URL=postgres://... npm run db:migrate
 
 Vercel calls `GET /api/cron/ingest` daily at 10:00 UTC. The route returns a successful skipped state until both `CRON_SECRET` and a database URL are configured, so merging the foundation does not create a failing production job.
 
-The daily schedule is only the bootstrap cadence. Before regular-season launch, increase refreshes around official injury reports and kickoff. That may require Vercel Pro or an external scheduler. Provider calls remain isolated to ingestion; user-facing scenario requests read the latest stored snapshot.
+The daily schedule is only the bootstrap cadence. Before regular-season launch, increase refreshes around official injury reports and kickoff. That may require Vercel Pro or an external scheduler. Remote provider calls remain isolated to ingestion; user-facing scenario requests read the latest stored snapshot. Rest/Travel is the exception because it is deterministically derived from the local schedule and can be attached without a remote request.
 
 Required production variables:
 

--- a/docs/PRODUCT_CONTRACT.md
+++ b/docs/PRODUCT_CONTRACT.md
@@ -14,9 +14,15 @@ A canonical current-week matchup identified by `game_id`. The full regular-seaso
 
 ### Game Agent
 
-A selectable causal lens such as Weather, Pressure, Pace, Injury, Efficiency, Quarterback, Backfield, Receivers, Tight Ends, or Usage.
+A selectable game-level causal lens: Weather, Momentum, Pace, Injuries, Efficiency, Pressure, Trenches, Turnovers, Quarterback, or Rest/Travel.
 
 Agent selection is the user's implicit hypothesis. Agent events always retain the selected assumption and may attach provider observations with source quality, observed time, effective time, expiry, and raw-import lineage.
+
+Each resolved event contains an Agent Finding with one of four materiality states: `material`, `contextual`, `balanced`, or `unavailable`. The finding states the matchup mechanism, any directional team path, up to four decisive signals, and explicit caveats. Materiality describes whether the lens separates this matchup; it is not a confidence score or prediction probability.
+
+Each selectable agent owns one specialist question and one explicit football scope. Its purpose, required inputs, assumptions, signals, failure modes, anchor behavior, and pairings are defined in `docs/agents/`. These specifications guide scenario and script behavior without changing the distinction between a selected hypothesis and sourced evidence.
+
+Player positions are not Game Agents. Quarterback remains selectable because quarterback response can determine the entire game shape. Running Back, Wide Receiver, and Tight End are reserved as downstream Bet Station market families. Usage is an internal allocation input, and Volatility is a derived script property supported by mechanisms such as explosives, turnover exposure, and unstable conversion.
 
 ### Scenario
 
@@ -24,6 +30,7 @@ The stable resolution of one game plus selected agents. `scenario_id` identifies
 
 - selected agent IDs;
 - one causal event per selected agent;
+- one matchup-specific Agent Finding per event;
 - the complete anchor catalog;
 - compatible suggested anchor IDs;
 - an evidence-state label.
@@ -40,7 +47,7 @@ One structured story containing a title, summary, causal chain, conditions that 
 
 ### Bet Station
 
-The future downstream product. It will translate a completed Game Script into available markets and correlated positions using fresh, sourced lines. It is intentionally outside the Script Builder contract.
+The future downstream product. It will receive a versioned handoff from a completed Game Script and translate that story into available markets using fresh, sourced lines. Quarterback, Running Back, Wide Receiver, and Tight End are market filters here rather than Game Agents; role and Usage data determine which players can capture the story. Bet Station is intentionally outside the Script Builder contract.
 
 ## Terminal Behavior
 
@@ -49,11 +56,13 @@ The terminal is a visible state machine, not a command-line parser. Its output m
 1. active schedule loaded;
 2. matchup selected;
 3. agents selected and dispatched;
-4. latest stored snapshot attached and scenario events resolved;
+4. latest stored snapshot attached, schedule-derived context added where applicable, and Agent Findings resolved;
 5. anchors suggested and confirmed;
 6. Game Script generated.
 
 No terminal line may imply that live evidence was checked unless a provider observation with provenance was actually used.
+
+Agents do not vote or produce confidence scores. A balanced or unavailable finding is a valid result and must not be forced into an outcome anchor. Game Script generation is the synthesis layer: it connects compatible agent mechanisms, retains contradictions, and states the conditions and failure modes of the combined story.
 
 ## Non-Goals
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,7 +10,9 @@
 - Script-only contract with model and deterministic generation.
 - Provider-neutral observations, immutable game snapshots, and scenario/script lineage.
 - Postgres migrations and a secured daily ingestion boundary.
-- Official NWS weather plus research-grade nflverse injury and offensive EPA pilot adapters.
+- Official NWS weather, schedule-derived Rest/Travel, and research-grade nflverse Injury, Efficiency, Turnovers, and Trenches-proxy adapters.
+- Ten game-level selectable Game Agents with specialist specifications, explicit data support, causal assumptions, failure modes, and anchor behavior.
+- Position-market choices separated from Game Story selection through a versioned Bet Station handoff contract; Usage retained as internal allocation logic and Volatility retained as a derived script property.
 - Old wrapper app, hard-coded 2025 context, manual odds fallback, mode APIs, betting schemas, and historical implementation plans removed.
 
 ## 1. Live Scenario Data
@@ -20,8 +22,8 @@
 1. **Owner pending:** select the licensed production football/odds provider and refresh budget.
 2. **Implemented:** provider-neutral observations with source, observed time, game ID, subject, value, freshness, and source quality.
 3. **Implemented, configuration pending:** Postgres migration, immutable storage, last-valid carry-forward, and secured daily Vercel ingestion.
-4. **Pilot implemented:** Weather, Injury, and Efficiency agents can attach observations without changing the user-facing hypothesis flow.
-5. **Implemented:** terminal output distinguishes assumption, observed context, support, conflict, stale data, and missing data.
+4. **Pilot implemented:** Weather, Injury, Efficiency, Turnovers, Trenches, and Rest/Travel can attach observations without changing the user-facing hypothesis flow.
+5. **Implemented:** terminal output presents matchup-specific Agent Findings with material, contextual, balanced, and unavailable states plus source freshness.
 
 **Release gate:** every displayed factual claim has source and freshness provenance, and provider failure preserves the last valid snapshot.
 
@@ -29,10 +31,13 @@
 
 **Owner: Codex**
 
-1. Extend agent selection with optional subject and direction, such as home pass rush, away receiver usage, or game-level wind suppression.
-2. Keep one-click defaults while allowing lightweight agent configuration.
-3. Generate anchors from resolved agent directions and explain why each was suggested.
-4. Add contradiction handling when selected agents imply incompatible game shapes.
+1. **Implemented:** define one bounded specialist question, required input set, causal assumptions, failure modes, and pairings for each current Game Agent. See `docs/agents/README.md`.
+2. Extend agent selection with optional subject and direction, such as home pass rush, away quarterback response, or game-level wind suppression.
+3. Keep one-click defaults while allowing lightweight agent configuration.
+4. **Implemented for data-backed agents:** generate anchors from resolved material findings rather than static agent identity.
+5. Add contradiction handling when selected agents imply incompatible game shapes.
+6. **Pilot data-backed:** Trenches, Turnovers, and Rest/Travel. **Assumption-only:** Momentum. Derive volatility from resolved mechanisms instead of exposing another selector.
+7. Hold Scheme and Special Teams until their data, boundaries, and anchor needs are approved.
 
 **Release gate:** a user can express the common one-sentence thesis patterns without a free-text hypothesis box.
 
@@ -42,8 +47,9 @@
 
 1. **Foundation implemented:** fixture-based checks cover selected-agent representation, unsupported numeric facts, anchor validity, and useful failure conditions.
 2. **Implemented except user ownership:** store scenarios and scripts by game, snapshot, contract version, and input hash.
-3. Support script revisions by changing agents or anchors while retaining lineage.
-4. Add shareable, read-only script views after authentication and privacy decisions.
+3. Add agent-specific synthesis guidance and checks for causal specificity, cross-agent interaction, contradiction handling, and generic restatement.
+4. Support script revisions by changing agents or anchors while retaining lineage.
+5. Add shareable, read-only script views after authentication and privacy decisions.
 
 **Release gate:** repeated inputs are reproducible, revisions are traceable, and model changes pass the evaluation suite.
 
@@ -52,10 +58,12 @@
 **Owner: Shared**
 
 1. **Drafted, owner approval pending:** spreads and totals only, supported books, jurisdictions, responsible-gaming requirements, and product language. See `docs/BET_STATION_GUARDRAILS.md`.
-2. Codex maps Game Script causal steps to currently available markets using fresh lines.
-3. Rank candidate positions by story fit and dependency, not by fabricated expected value.
-4. Explain correlation, duplicated exposure, pricing time, and invalidation risk.
-5. Keep pricing and market availability out of the Script Builder.
+2. **Contract boundary implemented:** a Bet Station handoff preserves script, scenario revision, snapshot, game, and anchor lineage without adding markets to the Game Script.
+3. Codex maps Game Script causal steps to currently available markets using fresh lines.
+4. Rank candidate positions by story fit and dependency, not by fabricated expected value.
+5. Add QB, RB, WR, and TE market-family filters only when the approved market scope reaches player outcomes; power them with internal Usage and role data.
+6. Explain correlation, duplicated exposure, pricing time, and invalidation risk.
+7. Keep pricing and market availability out of the Script Builder.
 
 **Release gate:** every suggested market is currently available, time-stamped, attributable to a source, and linked to a specific causal step.
 

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,215 @@
+# Swantail Football Agent Blueprint
+
+## Purpose
+
+Swantail Game Agents are specialist causal lenses. A user selects the parts of a matchup they believe matter, each selected agent resolves one bounded football question, and Game Script generation combines those resolved events into one conditional story.
+
+This design borrows the strongest structural ideas from the CBB Agent Pack:
+
+- one specialist question per agent;
+- explicit scope boundaries;
+- declared inputs and missing-data behavior;
+- cross-matching one team's strength against the opponent's vulnerability;
+- a causal story rather than a list of statistics;
+- failure conditions that can break the story;
+- useful pairings between specialists;
+- synthesis only after the specialist outputs exist.
+
+Swantail does not inherit CBB edge ratings, picks, market verdicts, or confidence gates. Its synthesis object is the Game Script, and its output remains conditional rather than predictive.
+
+## Agent Contract
+
+Every agent specification answers the same questions:
+
+1. What football mechanism does this agent own?
+2. What matchup questions should it ask?
+3. What inputs are required for an observed conclusion?
+4. What assumptions can it express without observations?
+5. Which sourced signals support, contextualize, or conflict with the assumption?
+6. What can make the causal story fail?
+7. Which existing scenario anchors can the agent suggest?
+8. Which other agents help complete or challenge the story?
+
+The runtime distinction is mandatory:
+
+- `assumption_only`: the user selected a lens, but no supporting source observation was attached;
+- `observed_context`: sourced facts are relevant but not directional enough to support the assumption;
+- `observed_support`: sourced facts meet the agent's declared support logic;
+- `observed_conflict`: sourced facts cut against the selected assumption;
+- `stale` or `missing`: the observation layer cannot support a current claim.
+
+An agent never upgrades its own hypothesis into truth. Observations can support, conflict with, or add context to the hypothesis.
+
+## Resolution Standard
+
+The CBB pack's strongest operating pattern becomes the following football-native standard for every Swantail agent:
+
+1. **Cross-match:** Compare one team's relevant strength or exposure with the opponent mechanism that can enable or punish it. Two isolated team rankings are context, not yet a matchup finding.
+2. **Sufficiency:** Name the required inputs and preserve whether each input is sourced, stale, missing, or assumption-only.
+3. **Materiality:** Resolve as balanced or unavailable when the profiles are similar, the data is incomplete, or the mechanism is unlikely to affect this game. Never force a story because an agent was selected.
+4. **Causal chain:** Express the contribution as: if the observed matchup condition holds, then a football mechanism changes, which creates a specific game-script consequence.
+5. **Counter-case:** Name the most credible scheme, personnel, game-state, or sample-quality reason the mechanism could fail.
+6. **Scope:** Stay inside the specialist boundary. Pair agents to complete a story instead of allowing one agent to make unsupported claims about another domain.
+
+This replaces CBB edge ratings and confidence caps with Swantail's evidence states, structured findings, and explicit caveats.
+
+## Football-Native Catalog
+
+| Agent | Specialist question | Current data support | Primary pairings |
+| --- | --- | --- | --- |
+| Weather | Do conditions remove or weaken either team's preferred approach? | Pilot NWS observations after ingestion is configured | Quarterback, Pace, Injuries |
+| Momentum | Has opponent-adjusted execution changed enough to persist? | Assumption only | Efficiency, Injuries, Quarterback |
+| Pace | Which offense controls play volume, clock pressure, and possessions? | Assumption only | Efficiency, Quarterback, Trenches |
+| Injuries | Which unavailable function cannot be preserved by the replacement or scheme? | Pilot nflverse observations after ingestion is configured | Quarterback, Pressure, Trenches |
+| Efficiency/EPA | Where does offensive efficiency collide with defensive suppression? | Pilot offensive EPA observations after ingestion is configured | Pace, Pressure, Quarterback |
+| Pressure | Can the pass rush arrive before the offense reaches its answers? | Assumption only | Quarterback, Trenches, Efficiency |
+| Trenches | Where does each offensive line win or lose against the opposing defensive line? | Pilot result-based nflverse proxy after ingestion | Pressure, Efficiency, Quarterback |
+| Turnovers | Does ball risk collide with repeatable takeaway creation? | Pilot nflverse team profiles after ingestion | Pressure, Quarterback, Momentum |
+| Quarterback | Which quarterback can solve the matchup's coverage and pressure environment? | Assumption only | Pressure, Efficiency, Weather |
+| Rest/Travel | Does schedule context modify a specific football matchup? | Internal schedule-derived observations available immediately | Momentum, Injuries, Trenches |
+
+`pilot_observations` means the adapter and observation contract exist. It does not mean production ingestion is configured or that a current observation is available. Runtime `evidence_state` remains authoritative.
+
+## Recommended Product Priority
+
+This stack rank reflects causal leverage, repeatability, distinctiveness, realistic data support, and usefulness across an NFL week. It is a product and data-investment priority, not a confidence score or a claim that the top-ranked agent must be selected for every game.
+
+| Rank | Agent | Why it belongs here | Current readiness |
+| ---: | --- | --- | --- |
+| 1 | Efficiency/EPA | Establishes the most repeatable team-quality cross-match and the baseline every narrower story must explain. | Partial pilot; add defensive and opponent-adjusted splits |
+| 2 | Quarterback | The quarterback's response to coverage, pressure, and difficult downs is the largest individual driver of offensive shape. | Assumption only; high-value licensed-data target |
+| 3 | Injuries | A material absence can invalidate every baseline by changing roles, protection, coverage, or play calling. | Partial pilot; add depth chart, participation, and replacement quality |
+| 4 | Trenches | OL-versus-DL control affects both rushing efficiency and whether the passing game can function on schedule. | Result-based proxy; licensed unit grades remain valuable |
+| 5 | Pressure | A specific rush-protection-quarterback collision creates one of football's clearest drive-killing mechanisms. | Assumption only; pressure and protection charting required |
+| 6 | Pace | Play and possession volume determines how often efficiency and game-state mechanisms can compound. | Assumption only; play-by-play derivation is attainable |
+| 7 | Turnovers | Ball-risk cross-matches can swing possessions and field position, but process must be separated from recovery luck. | Partial pilot; add turnover-worthy plays and field-position value |
+| 8 | Weather | Highly causal when thresholds are crossed and largely irrelevant when they are not, making the no-finding state essential. | Strongest current external feed; team exposure still needed |
+| 9 | Rest/Travel | A real preparation and recovery modifier that should strengthen another football mechanism rather than lead the story alone. | Schedule observations active; workload enrichment pending |
+| 10 | Momentum | Recent form matters only after opponent, personnel, and game-state adjustment and often overlaps the stronger Efficiency lens. | Assumption only; rolling adjusted windows required |
+
+Ten selectable agents is the catalog ceiling for this phase. New football context should enrich an existing agent unless it owns a distinct causal question, has a credible data path, and changes the resulting Game Script.
+
+## CBB-to-NFL Translation
+
+| CBB pack logic | Swantail equivalent | Decision |
+| --- | --- | --- |
+| Momentum | Opponent-adjusted recent EPA, success, and role changes | Momentum; never reduce it to a win streak |
+| Pace and tempo | Seconds per snap, no-huddle rate, neutral pace, play volume | Pace |
+| Offensive strength | Offensive EPA, success rate, explosives, finishing drives | Efficiency plus Quarterback |
+| Defensive strength | Pressure, defensive EPA, success-rate suppression | Pressure plus future two-sided Efficiency inputs |
+| Shooting volatility | Explosive dependence and unstable conversion | Derived `high_variance` script characteristic, not a selectable agent |
+| Three-point mismatch | No direct NFL equivalent | Exclude; position matchup detail belongs in later Bet Station enrichment |
+| Foul trouble | No direct NFL equivalent | Exclude; penalty discipline can remain supporting context |
+| Injury and availability | Availability, replacement quality, role redistribution | Injuries; Usage becomes an internal Bet Station input |
+| Clutch and close games | Late-down, two-minute, and end-game execution | Future split within Quarterback or Scheme; avoid small-sample standalone claims |
+| Turnover and ball security | Sack-fumble, interception, fumble, takeaway interaction | Turnovers |
+| Team composition | Depth, personnel grouping, and role concentration | Injuries plus downstream Bet Station role allocation |
+| Coach and scheme | Personnel, coverage, blitz, motion, and adjustment interaction | Future Scheme agent after licensed charting data |
+| Seed and historical matchup | No sound NFL equivalent | Exclude |
+| Conference strength | No direct NFL equivalent | Exclude; NFL schedule adjustment belongs inside Efficiency |
+| Rest and scheduling | Rest differential, travel, short week, bye | Rest/Travel |
+| Brand perception and ATS | Market perception | Bet Station only; exclude from Game Script agents |
+| Weighted meta-synthesis | Conditional cross-agent story | Game Script generation without weights or confidence claims |
+| Rim efficiency | Run-game and front interaction | Trenches plus rushing splits inside Efficiency |
+
+## Pack Collaboration
+
+Agents do not vote. They contribute causal mechanisms that can reinforce, qualify, or contradict one another.
+
+1. **Selection:** The user selects one or more Game Agents. Selection is the implicit hypothesis.
+2. **Resolution:** Each agent emits one scenario event in catalog order.
+3. **Evidence attachment:** The latest game snapshot supplies only observations whose `agent_id` matches the specialist.
+4. **Contradiction retention:** Conflicting observations remain visible. They are not discarded to make the story cleaner.
+5. **Anchor suggestion:** Agents suggest only anchors already defined by the Game Script contract. Exclusive groups resolve deterministically.
+6. **Script synthesis:** The script connects the selected mechanisms, states what must remain true, and names ways the story fails.
+
+High-value pairings include:
+
+- Weather + Quarterback + Pace: conditions affect timing, depth, and available play volume.
+- Pressure + Quarterback: rush and protection meet the quarterback's pressure response.
+- Pace + Efficiency: play volume changes how often an efficiency gap can compound.
+- Injuries + Quarterback or Trenches: an absence matters through the game-level function it removes.
+- Momentum + Efficiency: recent change is checked against the stable season baseline.
+- Trenches + Pressure + Efficiency: line control connects protection, rushing success, and drive quality.
+- Turnovers + Pressure + Quarterback: disruption and decision-making establish whether ball risk can repeat; high variance is derived from the result.
+- Rest/Travel + Injuries: preparation and recovery modify an already constrained roster.
+
+## Data Tiers
+
+### Available pilot observations
+
+- Weather: NWS hourly kickoff forecast and venue enclosure state.
+- Injuries: nflverse weekly injury reports.
+- Efficiency: nflverse offensive EPA per play and league rank.
+- Turnovers: nflverse giveaways, interceptions, fumbles lost, defensive interceptions, forced fumbles, and recoveries.
+- Trenches: nflverse result-based protection, rushing-efficiency, sack/QB-hit, and tackle-for-loss proxy.
+- Rest/Travel: schedule-derived turnaround, schedule spot, road sequence, and venue-distance context.
+
+These feeds remain pilot inputs. Injuries and performance require licensing review before commercial production use.
+
+### Licensed Game Story data required
+
+- pressure rate, sacks, pass-rush win rate, protection and time-to-pressure;
+- situation-neutral pace, seconds per snap, no-huddle and play-volume splits;
+- quarterback clean/pressured EPA, CPOE, depth, scrambling, and turnover data;
+- depth charts, inactive status, replacement roles, and participation;
+- opponent-adjusted defensive efficiency and schedule context;
+- opponent-adjusted rolling form and recent play-level splits;
+- line play, blocking, front disruption, and box-count charting;
+- turnover-worthy plays, fumbles, takeaways, and field-position value;
+- play-level efficiency distributions and conversion volatility;
+- player snap load, travel, time-zone, and turnaround observations.
+
+### Reserved Bet Station data
+
+- player identity and current depth-chart role;
+- snaps, routes, carries, targets, first reads, air yards, and scoring-area opportunity;
+- alignment, coverage, box count, yards after contact, and role-specific efficiency;
+- current market identity, price, source book, quote time, and availability.
+
+## Disciplined Future Catalog
+
+Do not add another ID to `GAME_AGENT_IDS` until its observation contract, assumption language, and anchor behavior are approved.
+
+1. **Scheme:** Detect personnel, motion, coverage, blitz, and formation interactions. Requires licensed charting data and careful boundaries with Pressure, Quarterback, and Efficiency.
+2. **Special Teams:** Consider only after Swantail has a clear user hypothesis and anchor need for field position, kicking, and return effects.
+
+Penalty discipline, coaching history, generic home-field narratives, and market perception should remain supporting context rather than selectable Game Agents.
+
+## Runtime Integration
+
+The current implementation remains valid:
+
+- `GAME_AGENT_IDS` is the canonical selectable set.
+- `GAME_AGENT_CATALOG` maps each ID to user-facing language and its specification.
+- `AGENT_EVENTS` in `lib/terminal/scenario.ts` provides the assumption-only event.
+- `eventEvidence` attaches and interprets current observations.
+- `eventEvidence` produces a structured Agent Finding with materiality, direction, signals, and caveats.
+- Material data-backed findings provide dynamic anchor suggestions; balanced and unavailable findings provide none.
+- `ScenarioEventSchema` preserves the assumption, Agent Finding, evidence state, observations, and anchors.
+- Game Script generation receives those scenario events and must preserve their evidence distinctions.
+
+Recommended later code changes, in order:
+
+1. Move assumption and anchor guidance into one typed agent registry so catalog metadata and scenario behavior cannot drift.
+2. Add directional agent configuration, such as `home_pressure`, `away_qb_response`, or `game_weather_suppression`, without adding a free-text thesis object.
+3. Add provider adapters only by extending the observation contract and immutable snapshot first.
+4. Give Game Script generation compact agent-specific synthesis guidance derived from these specs.
+5. Extend evaluations to check causal specificity, cross-agent interaction, contradiction handling, and generic restatement.
+
+No change should introduce odds, parlays, expected value, confidence guarantees, or unsupported facts into the Game Script contract.
+
+## Specification Index
+
+- [Weather](weather.md)
+- [Momentum](momentum.md)
+- [Pressure](pressure.md)
+- [Pace](pace.md)
+- [Injuries](injuries.md)
+- [Efficiency/EPA](efficiency-epa.md)
+- [Trenches](trenches.md)
+- [Turnovers](turnovers.md)
+- [Quarterback](quarterback.md)
+- [Rest/Travel](rest-travel.md)
+
+The former [Backfield](backfield.md), [Receivers](receivers.md), [Tight Ends](tight-ends.md), and [Usage](usage.md) specifications remain as Bet Station research references. [Volatility](volatility.md) remains as internal Game Script synthesis guidance. None is a selectable v5 Game Agent.

--- a/docs/agents/backfield.md
+++ b/docs/agents/backfield.md
@@ -1,0 +1,74 @@
+# Backfield Agent
+
+`bet_station_position_id: rb`
+`legacy_game_agent_id: hb`
+
+**Status:** Bet Station research reference. This is not a selectable Game Script v5 agent.
+
+## Purpose
+
+Determine whether a backfield can create efficient, repeatable control through rushing, receiving, and down-and-distance management.
+
+## Scope Boundary
+
+Backfield owns runner efficiency, role versatility, and what the backs create within the matchup. Trenches owns the blocking environment, while Usage owns how carries, routes, and high-value touches are allocated.
+
+## Core Football Questions
+
+- Can the offense generate successful runs rather than merely accumulate carries?
+- Does the opposing front create penetration, force negative plays, or invite efficient boxes?
+- Is the backfield concentrated or committee-based?
+- Can receiving and pass protection keep the backfield involved when the offense falls behind?
+
+## Required Inputs
+
+- Team and player rushing EPA, success rate, explosive rate, and stuff rate.
+- Yards after contact, missed tackles forced, and designed versus scramble separation.
+- Box count, run concept, offensive-line and defensive-front measures.
+- Snap, carry, route, target, short-yardage, and red-zone shares.
+
+**Current support:** Assumption-only. Swantail has no active rushing, line, front, or player-usage adapter.
+
+## Causal Assumptions
+
+- Efficient early-down rushing can preserve the playbook and shorten the opponent's opportunity count.
+- Carry volume without success does not establish control.
+- Receiving and protection roles determine whether a back stays on the field across game states.
+- Front and blocking interaction matters more than a running back's raw yardage average.
+
+## Useful Signals
+
+- Rushing success and EPA by box count and concept.
+- Stuff rate and yards before versus after contact.
+- Short-yardage and red-zone role.
+- Two-minute and third-down snaps.
+- Role change after an injury or depth-chart move.
+
+## Failure Modes
+
+- The offense falls behind and abandons the run.
+- The defensive front wins before the runner reaches the designed point of attack.
+- A committee splits the assumed volume.
+- The quarterback keeps or scrambles on designed run looks.
+- Raw rushing volume masks low efficiency and repeated long-yardage situations.
+
+## Suggested Anchors
+
+Current defaults: `run_heavy`, `grind`.
+
+## Useful Pairings
+
+Pace, Usage, Injuries, Pressure, and Efficiency/EPA.
+
+## Example Output Shape
+
+```json
+{
+  "agent_id": "hb",
+  "assumption": "Backfield volume and rushing success make control central to the result.",
+  "statement": "The backfield-control hypothesis is selected, but no sourced rushing or front observation is attached.",
+  "evidence_state": "assumption_only",
+  "observations": [],
+  "suggested_anchor_ids": ["run_heavy", "grind"]
+}
+```

--- a/docs/agents/efficiency-epa.md
+++ b/docs/agents/efficiency-epa.md
@@ -1,0 +1,74 @@
+# Efficiency/EPA Agent
+
+`agent_id: epa`
+
+## Purpose
+
+Detect a repeatable efficiency mismatch that can compound across ordinary possessions rather than depending on a rare event.
+
+## Scope Boundary
+
+Efficiency/EPA owns the broad offense-versus-defense cross-match after opponent and game-state adjustment. It identifies where quality compounds, while Quarterback, Pressure, Trenches, and the position agents explain the specific mechanism.
+
+## Core Football Questions
+
+- Which offense creates more expected value per play and with what level of consistency?
+- Is the gap driven by passing, rushing, explosives, success rate, or finishing drives?
+- Does the opposing defense specifically suppress that strength?
+- Is the sample current, opponent-adjusted, and stable across game states?
+
+## Required Inputs
+
+- Offensive and defensive EPA per play.
+- Success rate, explosive-play rate, early-down efficiency, and finishing-drives measures.
+- Opponent and schedule adjustment, sample games, and through-week metadata.
+- Splits by pass/rush and neutral/trailing/leading state.
+
+**Current support:** Pilot nflverse offensive EPA per play and league rank after ingestion is configured. Week 1 uses the prior regular season; later weeks use completed current-season weeks. Defensive and opponent-adjusted inputs are not yet attached.
+
+## Causal Assumptions
+
+- A broad efficiency advantage is more repeatable when it appears in success rate as well as explosives.
+- Efficiency compounds more strongly when Pace creates additional plays.
+- Offensive EPA alone cannot establish how the matchup behaves against the specific opposing defense.
+- A prior-season Week 1 baseline is context, not proof that the current roster retains the same quality.
+
+## Useful Signals
+
+- Offensive EPA per play and league rank gap.
+- Pass and rush EPA decomposition.
+- Early-down success rate and third-down distance.
+- Explosive rate versus steady success rate.
+- Red-zone and finishing-drive conversion.
+- Opponent-adjusted rolling windows.
+
+## Failure Modes
+
+- Turnovers or defensive scores dominate a small number of possessions.
+- The apparent gap is driven by opponent quality or garbage time.
+- Personnel or coordinator changes make the sample non-comparable.
+- One team wins a specific pressure, coverage, or trench matchup that aggregate EPA misses.
+- The current adapter supplies only offense, leaving the defensive cross-match unresolved.
+
+## Suggested Anchors
+
+Current default: `blowout`.
+
+The current non-directional contract does not identify which team owns the efficiency advantage, so winner and spread anchors remain user-confirmed rather than agent-suggested.
+
+## Useful Pairings
+
+Pace, Pressure, Quarterback, and Trenches.
+
+## Example Output Shape
+
+```json
+{
+  "agent_id": "epa",
+  "assumption": "The stronger efficiency profile compounds across possessions.",
+  "statement": "The attached offensive EPA ranks show a material gap, but the defensive cross-match is not yet sourced.",
+  "evidence_state": "observed_support",
+  "observations": ["team.offensive_epa_per_play"],
+  "suggested_anchor_ids": ["blowout"]
+}
+```

--- a/docs/agents/injuries.md
+++ b/docs/agents/injuries.md
@@ -1,0 +1,73 @@
+# Injuries Agent
+
+`agent_id: injury`
+
+## Purpose
+
+Identify availability changes that materially alter a team's role distribution, scheme options, protection, coverage, or efficiency.
+
+## Scope Boundary
+
+Injuries owns confirmed availability, functional role loss, and replacement consequences. It does not make a medical prognosis or treat a designation as proof of reduced performance without participation and role evidence.
+
+## Core Football Questions
+
+- Is the player expected to be active, limited, or absent?
+- What role disappears or changes if the player is limited?
+- Is the replacement capable of preserving the same scheme?
+- Which teammates inherit snaps, routes, touches, targets, protection, or coverage responsibility?
+- Does the absence affect offense, defense, or both sides of the matchup story?
+
+## Required Inputs
+
+- Official practice and game-status reports with timestamps.
+- Position, team, active status, and injury designation.
+- Future licensed enrichment: depth chart, expected participation, replacement player, snap history, and on/off efficiency.
+
+**Current support:** Pilot nflverse report observations after ingestion is configured. The current feed can establish report status, but not replacement quality or expected workload.
+
+## Causal Assumptions
+
+- Availability matters through lost function, not name recognition alone.
+- A concentrated role creates more redistribution than a rotational role.
+- Offensive-line and secondary absences can change several agents at once.
+- Questionable status is context, not proof of limitation or absence.
+
+## Useful Signals
+
+- `out`, `doubtful`, and `questionable` game designations.
+- Practice participation trend and late-week downgrade.
+- Prior snap, route, touch, target, protection, or coverage share.
+- Replacement experience and role compatibility.
+- Clustered injuries at one position group.
+
+## Failure Modes
+
+- The player is active without a meaningful limitation.
+- The replacement preserves the role more effectively than assumed.
+- Scheme changes distribute the missing role across several players.
+- The report is stale, ambiguous, or not an official game designation.
+- The selected anchors assume offensive suppression while the material absence is defensive.
+
+## Suggested Anchors
+
+Current defaults: `game_under`, `grind`.
+
+These defaults are intentionally narrow and represent offensive-availability suppression. Directional subject selection is required before injuries can safely imply higher scoring, passing concentration, rushing concentration, or a team-specific outcome.
+
+## Useful Pairings
+
+Quarterback, Pressure, Trenches, Efficiency/EPA, and Rest/Travel.
+
+## Example Output Shape
+
+```json
+{
+  "agent_id": "injury",
+  "assumption": "A material absence redistributes responsibility and reduces execution margin.",
+  "statement": "Two current material availability reports are attached; the downstream role change still requires depth and usage context.",
+  "evidence_state": "observed_support",
+  "observations": ["player.injury_status"],
+  "suggested_anchor_ids": ["game_under", "grind"]
+}
+```

--- a/docs/agents/momentum.md
+++ b/docs/agents/momentum.md
@@ -1,0 +1,73 @@
+# Momentum Agent
+
+`agent_id: momentum`
+
+## Purpose
+
+Detect whether recent opponent-adjusted performance reflects a meaningful change in team quality, role, or scheme rather than a superficial winning or losing streak.
+
+## Scope Boundary
+
+Momentum owns change from a stable team baseline. It does not treat wins, losses, confidence, or a short hot streak as evidence by themselves, and it leaves full-season quality to Efficiency/EPA.
+
+## Core Football Questions
+
+- Has either team's efficiency changed relative to its full-season baseline?
+- Is the change broad across success rate, explosives, and drive finishing, or driven by a few unstable plays?
+- Did personnel, play calling, or opponent quality change during the recent window?
+- Is the recent form likely to persist in this specific matchup?
+
+## Required Inputs
+
+- Rolling offensive and defensive EPA and success rate.
+- Explosive-play rate, early-down efficiency, and finishing-drives splits.
+- Opponent quality, game state, and recent personnel or coordinator changes.
+- At least a three-game window plus a stable season baseline.
+
+**Current support:** Assumption-only. The current EPA pilot supplies a baseline but not rolling, opponent-adjusted form observations.
+
+## Causal Assumptions
+
+- Momentum is a measurable change in process, not a win streak.
+- Recent improvement matters only when it survives opponent and game-state adjustment.
+- Personnel and scheme changes are more likely to persist than turnover luck or one-play variance.
+- A real form gap can compound into early control and scoreboard separation.
+
+## Useful Signals
+
+- Rolling EPA and success-rate change versus season baseline.
+- Early-down and neutral-state improvement.
+- Reduced pressure or sack exposure after a protection change.
+- Stable role changes after injury or depth-chart movement.
+- Opponent-adjusted drive success and finishing.
+
+## Failure Modes
+
+- The recent window contains weak opponents or garbage-time production.
+- Turnover margin or defensive scores explain most of the improvement.
+- The personnel or schematic change does not carry into this matchup.
+- Regression in explosive plays or conversion erases the apparent trend.
+- The sample is too short to distinguish signal from noise.
+
+## Suggested Anchors
+
+Current default: `blowout`.
+
+This anchor represents a meaningful form gap compounding into separation. Team direction must be added before Momentum can suggest a winner or cover.
+
+## Useful Pairings
+
+Efficiency/EPA, Injuries, Quarterback, and Trenches.
+
+## Example Output Shape
+
+```json
+{
+  "agent_id": "momentum",
+  "assumption": "A meaningful recent change in opponent-adjusted execution carries forward.",
+  "statement": "Momentum is selected as a causal lens, but no sourced rolling-performance observation is attached.",
+  "evidence_state": "assumption_only",
+  "observations": [],
+  "suggested_anchor_ids": ["blowout"]
+}
+```

--- a/docs/agents/pace.md
+++ b/docs/agents/pace.md
@@ -1,0 +1,73 @@
+# Pace Agent
+
+`agent_id: pace`
+
+## Purpose
+
+Determine which team can control snap tempo, play volume, and possession rhythm, then explain what each offense gains or loses at that pace.
+
+## Scope Boundary
+
+Pace owns how many plays and possessions the game can create or remove. It does not infer scoring direction from speed alone; Efficiency/EPA and the position agents determine what either offense can do with that volume.
+
+## Core Football Questions
+
+- Which team plays faster in situation-neutral settings?
+- Is tempo a stable identity or a product of score and opponent?
+- Can the faster team force pace, or can the slower team shorten possessions through rushing and clock control?
+- Which offense is more dependent on volume to create scoring chances?
+
+## Required Inputs
+
+- Situation-neutral seconds per snap and no-huddle rate.
+- Plays per game adjusted for overtime and game state.
+- Early-down pass rate, drive length, and possession count.
+- Opponent-adjusted pace effect and recent role or coordinator changes.
+
+**Current support:** Assumption-only. Schedule data supplies kickoff context but not play-by-play pace observations.
+
+## Causal Assumptions
+
+- Faster neutral tempo creates more plays and more opportunities for efficiency or usage to compound.
+- Successful rushing and sustained drives can suppress the opponent's play volume without a team literally snapping slowly.
+- Incompletions and clock stoppages can increase possession count; raw seconds per snap is not enough by itself.
+- Pace matters through the offenses using the additional or removed plays.
+
+## Useful Signals
+
+- Situation-neutral seconds per snap.
+- No-huddle and first-half pace.
+- Plays per drive and drives per game.
+- Neutral pass rate and incompletion rate.
+- Opponent pace effect after controlling for score.
+
+## Failure Modes
+
+- Early scoring changes both teams' neutral tendencies.
+- Long drives reduce possessions despite fast snap tempo.
+- Turnovers or defensive scores distort expected play volume.
+- A coordinator, quarterback, or offensive-line change invalidates season averages.
+- Both teams have similar pace profiles and no real collision exists.
+
+## Suggested Anchors
+
+Current defaults: `game_over`, `shootout`.
+
+These defaults represent a faster-volume hypothesis. A future directional pace contract should also support deliberate compression and grind scenarios.
+
+## Useful Pairings
+
+Efficiency/EPA, Quarterback, Trenches, and Turnovers.
+
+## Example Output Shape
+
+```json
+{
+  "agent_id": "pace",
+  "assumption": "A faster possession cycle increases play volume and scoring paths.",
+  "statement": "Pace is selected as a causal lens, but no sourced neutral-tempo observation is attached.",
+  "evidence_state": "assumption_only",
+  "observations": [],
+  "suggested_anchor_ids": ["game_over", "shootout"]
+}
+```

--- a/docs/agents/pressure.md
+++ b/docs/agents/pressure.md
@@ -1,0 +1,73 @@
+# Pressure Agent
+
+`agent_id: pressure`
+
+## Purpose
+
+Detect a pass-rush and protection collision that can shorten quarterback timing, create sacks, or make drives fragile.
+
+## Scope Boundary
+
+Pressure owns pass-rush arrival, protection response, and quarterback behavior after disruption. Trenches owns the broader offensive-line versus defensive-line battle, including run blocking and unit rankings.
+
+## Core Football Questions
+
+- Can either defense create pressure without sacrificing coverage integrity?
+- Does an offensive line have a specific weakness against the opponent's rush structure?
+- How does each quarterback respond when moved off the first read or platform?
+- Can protection answers such as quick game, screens, movement, or extra blockers neutralize the mismatch?
+
+## Required Inputs
+
+- Defensive pressure, sack, blitz, and pass-rush win rates.
+- Offensive pressure allowed, sack allowed, time-to-pressure, and protection usage.
+- Quarterback clean-pocket and pressured EPA, completion, scramble, and sack-avoidance splits.
+- Future enrichment: individual line matchups, simulated pressure, stunt rate, and chip/help tendencies.
+
+**Current support:** Assumption-only. Swantail has no active pressure or protection observation adapter.
+
+## Causal Assumptions
+
+- Fast pressure reduces time for route development and lowers downfield efficiency.
+- Sacks create down-and-distance problems that end drives more reliably than raw pressure alone.
+- Pressure is most material when the quarterback or protection unit lacks a proven counter.
+- Blitz rate is not pressure quality; the defense must create disruption without repeatedly conceding explosives.
+
+## Useful Signals
+
+- Defense pressure rate against offense pressure-allowed rate.
+- Sack conversion relative to pressure creation.
+- Quarterback EPA and sack rate under pressure.
+- Early-down pressure and third-down distance creation.
+- Protection changes after injuries or lineup movement.
+
+## Failure Modes
+
+- The offense wins with quick throws, screens, movement, or max protection.
+- The defense creates pressure but loses contain or coverage behind it.
+- Game state removes obvious passing situations.
+- Pressure comes late enough that the quarterback still completes the intended concept.
+- The assumed line matchup changes before kickoff.
+
+## Suggested Anchors
+
+Current defaults: `game_under`, `grind`.
+
+Directional pressure and turnover contracts are needed before suggesting a winner, cover, or blowout anchor.
+
+## Useful Pairings
+
+Quarterback, Trenches, Efficiency/EPA, and Weather.
+
+## Example Output Shape
+
+```json
+{
+  "agent_id": "pressure",
+  "assumption": "The pass-rush mismatch disrupts timing and drive survival.",
+  "statement": "Pressure is selected as a causal lens, but no sourced protection or quarterback split is attached.",
+  "evidence_state": "assumption_only",
+  "observations": [],
+  "suggested_anchor_ids": ["game_under", "grind"]
+}
+```

--- a/docs/agents/quarterback.md
+++ b/docs/agents/quarterback.md
@@ -1,0 +1,73 @@
+# Quarterback Agent
+
+`agent_id: qb`
+
+## Purpose
+
+Identify the quarterback mechanism most likely to determine drive quality, explosive access, and the ceiling or fragility of the game script.
+
+## Scope Boundary
+
+Quarterback owns the passer's decisions, accuracy, mobility, sack avoidance, and response to coverage and pressure. It does not stand in for team-level efficiency, protection quality, or receiver access.
+
+## Core Football Questions
+
+- How efficient is the quarterback from a clean pocket and under pressure?
+- Does the quarterback create value through accuracy, depth, timing, scrambling, or structure-breaking plays?
+- Which opposing coverage or rush behavior attacks the quarterback's weakest response?
+- Can the offense stay on schedule without asking the quarterback to repeatedly solve difficult downs?
+
+## Required Inputs
+
+- EPA per dropback, CPOE, success rate, yards per attempt, and explosive-pass rate.
+- Clean-pocket and pressured splits, sack rate, scramble rate, and time to throw.
+- Average depth of target, play-action, motion, and coverage splits.
+- Turnover-worthy play or interception context with stable sample metadata.
+
+**Current support:** Assumption-only. Swantail has no active quarterback observation adapter.
+
+## Causal Assumptions
+
+- Clean-pocket efficiency sets the ceiling, while pressured response often defines fragility.
+- A quarterback who avoids sacks can preserve drives even when pressure arrives.
+- Deep passing requires protection and receiver access; quarterback metrics cannot stand alone.
+- Scrambling can convert pressure into value but may also increase hit and fumble exposure.
+
+## Useful Signals
+
+- EPA and success rate by pocket state.
+- Pressure-to-sack rate and scramble conversion.
+- First-read versus late-progression efficiency.
+- Depth, middle-of-field, and coverage-shell splits.
+- Early-down passing efficiency and third-down burden.
+
+## Failure Modes
+
+- Protection keeps the quarterback cleaner than expected.
+- Receivers fail to win against coverage despite sound quarterback play.
+- The run game removes difficult down-and-distance situations.
+- Weather compresses the intended passing profile.
+- Small-sample pressure or coverage splits overstate a real tendency.
+
+## Suggested Anchors
+
+Current defaults: `game_over`, `pass_heavy`.
+
+These defaults represent a quarterback-led offensive hypothesis. Directional configuration and observed opponent data are required before suggesting a winner or spread anchor.
+
+## Useful Pairings
+
+Pressure, Efficiency/EPA, Trenches, Weather, and Pace.
+
+## Example Output Shape
+
+```json
+{
+  "agent_id": "qb",
+  "assumption": "Quarterback efficiency is the hinge for sustained drives and explosive scoring.",
+  "statement": "Quarterback play is selected as the game driver, but no sourced pocket or coverage split is attached.",
+  "evidence_state": "assumption_only",
+  "observations": [],
+  "suggested_anchor_ids": ["game_over", "pass_heavy"]
+}
+```

--- a/docs/agents/receivers.md
+++ b/docs/agents/receivers.md
@@ -1,0 +1,74 @@
+# Receivers Agent
+
+`bet_station_position_id: wr`
+`legacy_game_agent_id: wr`
+
+**Status:** Bet Station research reference. This is not a selectable Game Script v5 agent.
+
+## Purpose
+
+Detect where route participation, target concentration, alignment, and coverage interaction can create repeatable passing access or explosive plays.
+
+## Scope Boundary
+
+Receivers owns route profile, alignment, and receiver-versus-coverage access. Quarterback owns delivery quality, and Usage owns who receives the opportunities; target volume alone is not a coverage edge.
+
+## Core Football Questions
+
+- Which receivers are actually on the field and earning first-read opportunities?
+- Where do they align, and which coverage defenders or shells meet those routes?
+- Is the offense built on volume, depth, yards after catch, or explosive conversion?
+- Can pressure or weather prevent the route tree from developing?
+
+## Required Inputs
+
+- Route participation, targets per route, target share, first-read share, and air-yard share.
+- Alignment, depth of target, yards after catch, and explosive reception rate.
+- Coverage shell, man/zone, corner alignment, safety help, and allowed route-profile data.
+- Red-zone and end-zone target shares.
+
+**Current support:** Assumption-only. Swantail has no active route, target, or coverage observation adapter.
+
+## Causal Assumptions
+
+- Routes create opportunity; targets without route context can misstate role strength.
+- Concentrated first-read and air-yard usage creates a clear path for passing volume to accumulate.
+- Coverage interaction must be specific to alignment and route family, not a generic corner-versus-receiver label.
+- Pressure and weather can remove deep-developing routes before coverage becomes the deciding mechanism.
+
+## Useful Signals
+
+- Route participation and targets per route.
+- First-read, target, and air-yard concentration.
+- Slot, perimeter, motion, and condensed-formation usage.
+- Man/zone and coverage-shell performance.
+- End-zone and red-zone target share.
+
+## Failure Modes
+
+- Coverage rolls help toward the expected focal receiver.
+- Pressure prevents route development.
+- Targets redistribute to tight ends or backs.
+- The offense leads and reduces passing volume.
+- Injury or snap limitation changes the route hierarchy.
+
+## Suggested Anchors
+
+Current defaults: `game_over`, `pass_heavy`.
+
+## Useful Pairings
+
+Quarterback, Pressure, Usage, Tight Ends, and Weather.
+
+## Example Output Shape
+
+```json
+{
+  "agent_id": "wr",
+  "assumption": "Receiver concentration creates repeatable explosive-play opportunities.",
+  "statement": "The receiver-access hypothesis is selected, but no sourced route or coverage observation is attached.",
+  "evidence_state": "assumption_only",
+  "observations": [],
+  "suggested_anchor_ids": ["game_over", "pass_heavy"]
+}
+```

--- a/docs/agents/rest-travel.md
+++ b/docs/agents/rest-travel.md
@@ -1,0 +1,78 @@
+# Rest / Travel Agent
+
+`agent_id: rest`
+
+## Purpose
+
+Detect whether turnaround, travel, time-zone change, or accumulated workload creates a preparation or fatigue asymmetry relevant to execution.
+
+## Scope Boundary
+
+Rest/Travel owns the schedule modifier, not a standalone team-quality edge. A material finding must connect recovery or preparation time to a specific personnel, unit, or scheme mechanism and remain secondary when the football mismatch is larger.
+
+## Core Football Questions
+
+- How many days separate each team's games?
+- Is either team on a short week, after overtime, or returning from extended travel?
+- Does travel cross time zones or materially alter routine?
+- Did recent snap concentration place unusual load on key units?
+- Is extra rest likely to improve preparation, or does a personnel change limit that benefit?
+
+## Required Inputs
+
+- Previous game end time, current kickoff, venue, and travel distance.
+- Time-zone change, short-week, bye, overtime, and international-game flags.
+- Recent offensive and defensive snap counts by player and unit.
+- Injury and participation context during the turnaround.
+
+**Current support:** Internal schedule-derived observations are active. They cover regular-season turnaround, short/standard/extended schedule spot, current-site travel distance, and consecutive road games. Week 1 intentionally reports no prior regular-season turnaround. Overtime and player snap load remain future inputs.
+
+## Causal Assumptions
+
+- Short preparation can reduce installation and recovery time, especially after high snap volume.
+- Travel effects depend on direction, distance, timing, and routine rather than miles alone.
+- Extra rest matters most when it enables a real preparation or health advantage.
+- Rest should modify a matchup mechanism, not replace football-quality analysis.
+
+## Useful Signals
+
+- Thursday turnaround, Monday-to-Sunday compression, or post-overtime week.
+- Bye-week or mini-bye preparation advantage.
+- Cross-country or international travel.
+- Concentrated recent snaps at offensive line, defensive line, or secondary.
+- Repeated road games and late return times.
+
+## Failure Modes
+
+- Both teams have equivalent turnaround and travel.
+- Rotation depth absorbs recent workload.
+- Extra rest produces no relevant scheme or health change.
+- The matchup quality gap overwhelms a modest schedule effect.
+- Narrative claims exceed the available schedule and participation evidence.
+
+## Suggested Anchors
+
+A material rest differential can suggest the winner anchor for the team with the cleaner recovery window. Contextual, balanced, and Week 1 findings do not force an outcome anchor.
+
+## Useful Pairings
+
+Momentum, Injuries, Trenches, Pace, and Efficiency/EPA.
+
+## Example Output Shape
+
+```json
+{
+  "agent_id": "rest",
+  "assumption": "Turnaround and travel create a preparation or fatigue asymmetry.",
+  "finding": {
+    "state": "material",
+    "direction": "home",
+    "headline": "NE has the stronger rest profile",
+    "signals": [
+      { "label": "Turnaround", "away_value": "7 days", "home_value": "10.7 days" }
+    ]
+  },
+  "evidence_state": "observed_support",
+  "suggested_anchor_ids": ["home_win"]
+}
+```

--- a/docs/agents/tight-ends.md
+++ b/docs/agents/tight-ends.md
@@ -1,0 +1,74 @@
+# Tight Ends Agent
+
+`bet_station_position_id: te`
+`legacy_game_agent_id: te`
+
+**Status:** Bet Station research reference. This is not a selectable Game Script v5 agent.
+
+## Purpose
+
+Determine whether tight-end alignment and usage can unlock the middle of the field, create matchup stress, or become a red-zone conversion mechanism.
+
+## Scope Boundary
+
+Tight Ends owns the position-specific route, blocking, and coverage tradeoff. It should resolve only when tight-end deployment creates a distinct mechanism that the broader Receivers or Usage agents would miss.
+
+## Core Football Questions
+
+- Is the tight end running routes or staying in to protect?
+- Does the defense concede middle-field, seam, play-action, or red-zone access?
+- Which defender or coverage rule carries the tight end by alignment?
+- Does pressure increase quick middle-field targets or force the tight end into protection?
+
+## Required Inputs
+
+- Route participation, targets per route, target share, and alignment.
+- Inline, slot, wide, motion, and play-action usage.
+- Middle-of-field, seam, third-down, red-zone, and end-zone targets.
+- Opponent coverage and allowed production by alignment or route family.
+
+**Current support:** Assumption-only. Swantail has no active tight-end usage or coverage observation adapter.
+
+## Causal Assumptions
+
+- Tight-end value depends on route opportunity; raw snaps can include substantial blocking work.
+- Middle-field access can sustain drives even without explosive production.
+- Pressure can increase short-area opportunity or remove routes through added protection.
+- Red-zone usage is valuable only if the offense reaches scoring position often enough.
+
+## Useful Signals
+
+- Route participation relative to total snaps.
+- Targets per route and first-read share.
+- Seam, play-action, and middle-of-field usage.
+- Third-down and red-zone target concentration.
+- Opponent linebacker, safety, and zone-spacing behavior.
+
+## Failure Modes
+
+- The tight end stays in to protect against pressure.
+- Wide receivers or backs capture the middle-field opportunities.
+- The defense brackets the seam or passes routes cleanly between zones.
+- The offense does not create enough red-zone possessions.
+- Multiple tight ends split routes and targets.
+
+## Suggested Anchors
+
+Current default: `pass_heavy`.
+
+## Useful Pairings
+
+Quarterback, Pressure, Receivers, Usage, and Efficiency/EPA.
+
+## Example Output Shape
+
+```json
+{
+  "agent_id": "te",
+  "assumption": "Middle-field and red-zone access make tight-end involvement a conversion mechanism.",
+  "statement": "The tight-end access hypothesis is selected, but no sourced route or coverage observation is attached.",
+  "evidence_state": "assumption_only",
+  "observations": [],
+  "suggested_anchor_ids": ["pass_heavy"]
+}
+```

--- a/docs/agents/trenches.md
+++ b/docs/agents/trenches.md
@@ -1,0 +1,79 @@
+# Trenches Agent
+
+`agent_id: trenches`
+
+## Purpose
+
+Compare each offensive line directly with the opposing defensive line to detect rankings-based advantages in rushing lanes, protection, pressure, and disruption.
+
+## Scope Boundary
+
+Trenches owns unit-level offensive-line versus defensive-line rankings across both run and pass phases. Pressure owns what pass-rush arrival does to the quarterback, while rushing splits inside Efficiency establish whether blocking control becomes successful offense.
+
+## Core Football Questions
+
+- How does each offensive line's run-blocking and pass-protection profile rank against the opposing defensive line?
+- Where does the offensive-line versus defensive-line battle create the clearest matchup edge?
+- Which offense can create movement or prevent penetration on early downs?
+- Which defensive line can generate pressure without surrendering rushing lanes or quarterback escape paths?
+- Are injuries or lineup changes creating a weak link?
+- Can either offense counter front strength with movement, quick game, screens, or formation changes?
+
+## Required Inputs
+
+- Run-block and pass-block win rates, pressure allowed, and time to pressure.
+- Defensive pressure, stuff, tackle-for-loss, and run-stop rates.
+- Rushing success, yards before contact, box count, and concept splits.
+- Starting line combinations, front personnel, and injury status.
+
+**Current support:** A pilot nflverse result-based proxy is active after ingestion. It cross-matches sack rate allowed and rushing EPA with defensive sacks/QB hits and tackles for loss. It is not an assignment-level line grade and must remain labeled as a proxy until licensed charting is attached.
+
+## Causal Assumptions
+
+- Front control keeps an offense in favorable down-and-distance and preserves the full playbook.
+- Penetration can suppress rushing efficiency even when raw carry volume remains high.
+- Protection quality determines whether deeper passing concepts have time to develop.
+- One weak line position can matter more than an aggregate unit grade against a targeted front.
+
+## Useful Signals
+
+- Pressure and sack rate allowed by line combination.
+- Run success and stuff rate by concept and box count.
+- Yards before contact and short-yardage conversion.
+- Defensive pressure without blitzing.
+- Interior versus edge mismatch and recent lineup continuity.
+
+## Failure Modes
+
+- Quick passing and movement neutralize the front mismatch.
+- Game state removes rushing volume or obvious passing downs.
+- Scheme creates favorable numbers despite a personnel disadvantage.
+- The expected starting line or front changes before kickoff.
+- Aggregate grades hide a matchup-specific strength elsewhere.
+
+## Suggested Anchors
+
+A material proxy finding suggests a team winner anchor and either `run_heavy` or `pass_heavy`, depending on whether the larger separation comes from the run or protection cross-match. Balanced and unavailable profiles suggest no anchor.
+
+## Useful Pairings
+
+Pressure, Quarterback, Pace, Efficiency/EPA, and Injuries.
+
+## Example Output Shape
+
+```json
+{
+  "agent_id": "trenches",
+  "assumption": "Line-of-scrimmage control keeps one offense on schedule and disrupts the other.",
+  "finding": {
+    "state": "material",
+    "direction": "home",
+    "headline": "The home team has the clearer trench-control path",
+    "signals": [
+      { "label": "Pass protection rank", "away_value": "#25 of 32", "home_value": "#8 of 32" }
+    ]
+  },
+  "evidence_state": "observed_support",
+  "suggested_anchor_ids": ["home_win", "run_heavy"]
+}
+```

--- a/docs/agents/turnovers.md
+++ b/docs/agents/turnovers.md
@@ -1,0 +1,77 @@
+# Turnovers Agent
+
+`agent_id: turnovers`
+
+## Purpose
+
+Detect a ball-security and takeaway collision capable of creating lost possessions, short fields, and rapid game-state changes.
+
+## Scope Boundary
+
+Turnovers owns repeatable ball-risk process and the offense-versus-defense takeaway cross-match. It discounts recovery luck, does not use raw turnover margin as a prediction, and leaves the broader range of outcomes to Volatility.
+
+## Core Football Questions
+
+- Does either quarterback expose the ball through interceptions, sacks, or pressured mistakes?
+- Does either offense have a fumble problem in the backfield or after the catch?
+- Can the opposing defense create takeaways through pressure, coverage disguise, or tackling?
+- Are turnover results supported by repeatable process or mostly recovery and interception luck?
+
+## Required Inputs
+
+- Interception, turnover-worthy play, fumble, and fumble-lost rates.
+- Pressure, sack-fumble, pass-breakup, and takeaway opportunity data.
+- Field position and points created from takeaways.
+- Game-state, quarterback, and ball-carrier attribution.
+
+**Current support:** Pilot nflverse team-stat observations are active after ingestion. The finding cross-matches giveaways, interception rate, fumbles lost, takeaways, and forced fumbles. It does not yet include turnover-worthy plays, pressure attribution, or field-position value.
+
+## Causal Assumptions
+
+- Turnovers matter through both the lost possession and the field position they create.
+- Pressure-caused mistakes are more matchup-relevant than raw season turnover margin.
+- Fumble recoveries and some interceptions are unstable, so opportunity matters more than results alone.
+- A turnover mismatch widens the range of plausible game shapes.
+
+## Useful Signals
+
+- Pressure-to-turnover and sack-fumble rates.
+- Turnover-worthy plays versus actual interceptions.
+- Fumbles by role and contact type.
+- Defensive takeaways supported by pressure and pass breakups.
+- Starting field position after takeaways.
+
+## Failure Modes
+
+- The offense protects the quarterback and avoids forced throws.
+- Turnover opportunities occur but recovery or interception variance goes the other way.
+- Conservative game state removes risky dropbacks.
+- The defense's turnover total is mostly non-repeatable luck.
+- A quarterback or ball-carrier change invalidates the baseline.
+
+## Suggested Anchors
+
+A material cross-match can suggest `high_variance` plus the winner anchor for the team with the cleaner turnover exchange. Balanced and unavailable profiles suggest no anchor.
+
+## Useful Pairings
+
+Pressure, Quarterback, Momentum, and Efficiency/EPA. A material finding can derive a high-variance script shape without a separate Volatility agent.
+
+## Example Output Shape
+
+```json
+{
+  "agent_id": "turnovers",
+  "assumption": "A ball-security mismatch creates short fields and lost possessions.",
+  "finding": {
+    "state": "material",
+    "direction": "home",
+    "headline": "The home team has the cleaner ball-security matchup",
+    "signals": [
+      { "label": "Cross-match exposure", "away_value": "elevated", "home_value": "contained" }
+    ]
+  },
+  "evidence_state": "observed_support",
+  "suggested_anchor_ids": ["home_win", "high_variance"]
+}
+```

--- a/docs/agents/usage.md
+++ b/docs/agents/usage.md
@@ -1,0 +1,77 @@
+# Usage Agent
+
+`bet_station_internal_lens: usage`
+`legacy_game_agent_id: usage`
+
+**Status:** Internal Bet Station allocation reference. Usage is not a selectable Game Script v5 agent or a user-facing market family.
+
+## Purpose
+
+Identify where snaps, routes, touches, targets, protection responsibilities, and high-value opportunities are likely to concentrate.
+
+## Scope Boundary
+
+Usage owns opportunity allocation and role redistribution across positions. It identifies who can capture a scenario, but does not claim that volume will be efficient or that a player wins the matchup.
+
+## Core Football Questions
+
+- Which roles are stable, expanding, shrinking, or newly available?
+- Is opportunity concentrated enough to create a dependable causal path?
+- Which game states keep the player on the field?
+- Does an injury or scheme change redistribute volume to one player or several?
+- Are the opportunities high value, such as routes, air yards, third downs, and red-zone work?
+
+## Required Inputs
+
+- Snap, route, carry, target, first-read, and air-yard shares.
+- Third-down, two-minute, short-yardage, red-zone, and end-zone roles.
+- Recent-week trends with injury and depth-chart context.
+- Personnel grouping, substitution, and game-state splits.
+
+**Current support:** Assumption-only. The injury pilot can identify availability context, but no current adapter supplies role participation or redistribution.
+
+## Causal Assumptions
+
+- Stable participation is the base layer; opportunity cannot accumulate from the sideline.
+- Routes and high-value touches matter more than raw snaps.
+- Concentration creates a clearer story than diffuse committee usage.
+- Usage does not guarantee efficiency; it identifies who captures the scenario if the offense succeeds.
+
+## Useful Signals
+
+- Route participation and snap share above role-specific thresholds.
+- First-read, target, air-yard, carry, and red-zone concentration.
+- Two-minute and third-down participation.
+- Changes after an injury, bye, trade, or coordinator adjustment.
+- Personnel packages that keep or remove a player by game state.
+
+## Failure Modes
+
+- A committee forms instead of one role inheriting volume.
+- The player participates but earns low-value opportunities.
+- Game state removes the expected package or role.
+- Efficiency collapses despite high volume.
+- Injury news or inactive status changes after the snapshot.
+
+## Suggested Anchors
+
+Current default: `pass_heavy`.
+
+This default is too narrow for backfield or defensive-injury redistribution. Directional subject selection should precede any broader usage-anchor behavior.
+
+## Useful Pairings
+
+Injuries, Quarterback, Backfield, Receivers, and Tight Ends.
+
+## Example Output Shape
+
+```json
+{
+  "agent_id": "usage",
+  "assumption": "A concentrated role funnels opportunity toward the likely volume captors.",
+  "statement": "Usage concentration is selected as a lens, but no sourced participation or role observation is attached.",
+  "evidence_state": "assumption_only",
+  "observations": [],
+  "suggested_anchor_ids": ["pass_heavy"]
+}
+```

--- a/docs/agents/volatility.md
+++ b/docs/agents/volatility.md
@@ -1,0 +1,74 @@
+# Volatility Agent
+
+`derived_script_property: high_variance`
+`legacy_game_agent_id: volatility`
+
+**Status:** Internal Game Script synthesis reference. Volatility is derived from resolved mechanisms and is not a selectable Game Script v5 agent.
+
+## Purpose
+
+Identify the mechanisms that widen the range of plausible game scripts, including explosive dependence, turnover exposure, unstable conversion, and concentrated high-leverage usage.
+
+## Scope Boundary
+
+Volatility owns outcome range, not a team advantage or automatic scoring direction. It synthesizes variance mechanisms without replacing the more specific Turnovers, Efficiency/EPA, or Usage findings that establish them.
+
+## Core Football Questions
+
+- Does either offense rely on explosives rather than steady success?
+- Are turnovers, fourth downs, or red-zone outcomes likely to swing possession value?
+- Is production concentrated in a small number of players or low-frequency plays?
+- Which stable mechanisms pull the game back toward its median outcome?
+
+## Required Inputs
+
+- Explosive pass and rush rates alongside success rate.
+- Turnover-worthy plays, fumbles, and takeaway opportunities.
+- Third- and fourth-down conversion, red-zone touchdown rate, and finishing drives.
+- Distribution of play-level EPA rather than average EPA alone.
+
+**Current support:** Assumption-only. The current EPA pilot supplies averages but not play-level distribution or conversion volatility.
+
+## Causal Assumptions
+
+- High average efficiency can still be fragile when it depends on a few explosive plays.
+- Turnovers and short fields create branching game states rather than one directional expectation.
+- Concentrated usage can increase both upside and failure risk.
+- Volatility describes outcome range, not automatically high scoring.
+
+## Useful Signals
+
+- Explosive rate paired with below-average success rate.
+- Large gap between mean and median play value.
+- Unstable third-down, fourth-down, or red-zone conversion.
+- Turnover opportunity rates and fumble recovery dependence.
+- Heavy dependence on one player or one route family.
+
+## Failure Modes
+
+- Both teams sustain ordinary success and avoid high-leverage swings.
+- The defense prevents explosives without conceding efficient underneath play.
+- Conversion rates regress toward stable baselines.
+- Game state becomes predictable enough to narrow the playbook.
+- A supposedly volatile profile is only a small-sample artifact.
+
+## Suggested Anchors
+
+Current default: `high_variance`.
+
+## Useful Pairings
+
+Turnovers, Quarterback, Receivers, Usage, and Momentum.
+
+## Example Output Shape
+
+```json
+{
+  "agent_id": "volatility",
+  "assumption": "Explosives, turnovers, and unstable conversion widen the range of outcomes.",
+  "statement": "Volatility is selected as a causal lens, but no sourced play-distribution observation is attached.",
+  "evidence_state": "assumption_only",
+  "observations": [],
+  "suggested_anchor_ids": ["high_variance"]
+}
+```

--- a/docs/agents/weather.md
+++ b/docs/agents/weather.md
@@ -1,0 +1,71 @@
+# Weather Agent
+
+`agent_id: weather`
+
+## Purpose
+
+Determine whether kickoff conditions materially narrow the available playbook or change execution risk. Weather is a game-level mechanism, not a generic reason to expect fewer points.
+
+## Scope Boundary
+
+Weather owns the environmental constraint at kickoff and each team's exposure to it. It does not assume bad weather means an under, or evaluate overall offensive quality without another agent supplying that mechanism.
+
+## Core Football Questions
+
+- Is the venue open, enclosed, retractable, or operationally uncertain?
+- Are wind, precipitation, temperature, or field conditions severe enough to alter passing depth, kicking, handling, or play selection?
+- Which offense is more exposed to the affected phase?
+- Do the conditions persist through the likely game window?
+
+## Required Inputs
+
+- Venue coordinates, roof state, kickoff time, and timezone.
+- Hourly temperature, sustained wind, precipitation probability, and forecast summary.
+- Future licensed enrichment: gusts, wind direction, field surface, roof decision, and offense-specific depth or kicking profiles.
+
+**Current support:** Pilot NWS observations after ingestion is configured. An enclosed venue can produce observed conflict. Without a current snapshot, this agent is assumption-only.
+
+## Causal Assumptions
+
+- Material wind can compress passing depth and increase the value of short throws and rushing attempts.
+- Heavy precipitation can increase handling risk and make lower-variance calls more attractive.
+- Conditions matter through a team's exposure to them; mild weather alone does not create a game script.
+- An enclosed venue conflicts with an exterior weather-suppression hypothesis.
+
+## Useful Signals
+
+- Sustained wind at or above the current 15 mph support threshold.
+- Precipitation probability at or above the current 40 percent support threshold.
+- Forecast changes between snapshots.
+- Roof state and forecast validity at kickoff.
+
+## Failure Modes
+
+- The forecast changes or the roof closes.
+- Wind direction or stadium shielding makes the headline wind less relevant.
+- Both offenses already rely on short-area passing and rushing.
+- Turnovers, defensive scores, or early deficits force aggressive game states.
+- The observation is stale or outside the reliable forecast horizon.
+
+## Suggested Anchors
+
+Current defaults: `game_under`, `grind`, `run_heavy`.
+
+These describe a weather-suppression hypothesis. Directional configuration is required before weather can safely suggest an aggressive passing or scoring anchor.
+
+## Useful Pairings
+
+Quarterback, Pace, Injuries, and Efficiency/EPA.
+
+## Example Output Shape
+
+```json
+{
+  "agent_id": "weather",
+  "assumption": "Kickoff conditions suppress clean execution and downfield play.",
+  "statement": "The sourced kickoff forecast supports a wind-driven compression of the passing game.",
+  "evidence_state": "observed_support",
+  "observations": ["weather.kickoff_forecast"],
+  "suggested_anchor_ids": ["game_under", "grind", "run_heavy"]
+}
+```

--- a/lib/bet-station/contracts.ts
+++ b/lib/bet-station/contracts.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod'
+import {
+  ScenarioAnchorIdSchema,
+  TERMINAL_CONTRACT_VERSION,
+  type GameScript,
+  type ScenarioResolution,
+} from '@/lib/terminal/contracts'
+
+export const BET_STATION_HANDOFF_VERSION = 'bet-station-handoff-v1'
+
+export const BET_STATION_POSITION_IDS = ['qb', 'rb', 'wr', 'te'] as const
+export const BetStationPositionIdSchema = z.enum(BET_STATION_POSITION_IDS)
+export type BetStationPositionId = z.infer<typeof BetStationPositionIdSchema>
+
+type BetStationPositionCatalogEntry = {
+  label: string
+  description: string
+}
+
+export const BET_STATION_POSITION_CATALOG: Record<BetStationPositionId, BetStationPositionCatalogEntry> = {
+  qb: {
+    label: 'Quarterback',
+    description: 'Passing, rushing, attempt, completion, and touchdown markets that express the resolved game story.',
+  },
+  rb: {
+    label: 'Running Back',
+    description: 'Rushing, receiving, touch, and scoring markets filtered through role concentration and game state.',
+  },
+  wr: {
+    label: 'Wide Receiver',
+    description: 'Target, reception, yardage, and scoring markets connected to route participation and matchup access.',
+  },
+  te: {
+    label: 'Tight End',
+    description: 'Receiving and scoring markets connected to routes, protection duty, middle-field access, and red-zone role.',
+  },
+}
+
+export const BET_STATION_INTERNAL_LENSES = ['usage'] as const
+
+export const BetStationHandoffSchema = z.object({
+  contract_version: z.literal(BET_STATION_HANDOFF_VERSION),
+  source_contract_version: z.literal(TERMINAL_CONTRACT_VERSION),
+  script_id: z.string().min(1),
+  scenario_id: z.string().min(1),
+  scenario_revision_id: z.string().min(1),
+  snapshot_id: z.string().min(1),
+  game_id: z.string().min(1),
+  anchor_ids: z.array(ScenarioAnchorIdSchema).min(1),
+})
+
+export type BetStationHandoff = z.infer<typeof BetStationHandoffSchema>
+
+export function createBetStationHandoff(params: {
+  scenario: ScenarioResolution
+  script: GameScript
+}): BetStationHandoff {
+  if (
+    params.script.scenario_id !== params.scenario.scenario_id
+    || params.script.scenario_revision_id !== params.scenario.scenario_revision_id
+    || params.script.snapshot_id !== params.scenario.snapshot_id
+  ) {
+    throw new Error('Bet Station handoff requires matching script and scenario lineage')
+  }
+
+  return BetStationHandoffSchema.parse({
+    contract_version: BET_STATION_HANDOFF_VERSION,
+    source_contract_version: TERMINAL_CONTRACT_VERSION,
+    script_id: params.script.script_id,
+    scenario_id: params.scenario.scenario_id,
+    scenario_revision_id: params.scenario.scenario_revision_id,
+    snapshot_id: params.scenario.snapshot_id,
+    game_id: params.scenario.game.game_id,
+    anchor_ids: params.script.anchor_ids,
+  })
+}

--- a/lib/data/contracts.ts
+++ b/lib/data/contracts.ts
@@ -3,7 +3,16 @@ import { GameSchema } from '@/lib/nfl/game'
 
 export const OBSERVATION_CONTRACT_VERSION = 'observation-v1'
 
-export const ObservationAgentIdSchema = z.enum(['weather', 'injury', 'epa'])
+export const OBSERVATION_AGENT_IDS = [
+  'weather',
+  'injury',
+  'epa',
+  'trenches',
+  'turnovers',
+  'rest',
+] as const
+
+export const ObservationAgentIdSchema = z.enum(OBSERVATION_AGENT_IDS)
 export const ObservationKindSchema = z.enum(['forecast', 'report', 'measurement', 'venue'])
 export const SourceQualitySchema = z.enum(['official', 'licensed', 'research', 'internal'])
 export const SnapshotFeedStateSchema = z.enum([
@@ -74,6 +83,9 @@ export const GameSnapshotSchema = z.object({
     weather: SnapshotAvailabilitySchema,
     injury: SnapshotAvailabilitySchema,
     epa: SnapshotAvailabilitySchema,
+    trenches: SnapshotAvailabilitySchema.optional(),
+    turnovers: SnapshotAvailabilitySchema.optional(),
+    rest: SnapshotAvailabilitySchema.optional(),
   }),
   content_hash: z.string().regex(/^[a-f0-9]{64}$/),
 }).superRefine((snapshot, context) => {

--- a/lib/data/ingest.ts
+++ b/lib/data/ingest.ts
@@ -13,12 +13,18 @@ import {
   persistIngestionBundle,
   recordFailedIngestionRun,
 } from '@/lib/data/repository'
-import { nflverseEpaProvider, nflverseInjuryProvider } from '@/lib/data/providers/nflverse'
+import { nflverseInjuryProvider, nflverseTeamStatsProvider } from '@/lib/data/providers/nflverse'
 import { nwsWeatherProvider } from '@/lib/data/providers/nws'
+import { scheduleRestProvider } from '@/lib/data/providers/rest'
 import { GameSchema } from '@/lib/nfl/game'
 import { loadOperationalSchedule } from '@/lib/nfl/schedule'
 
-const PROVIDERS = [nwsWeatherProvider, nflverseInjuryProvider, nflverseEpaProvider]
+const PROVIDERS = [
+  nwsWeatherProvider,
+  nflverseInjuryProvider,
+  nflverseTeamStatsProvider,
+  scheduleRestProvider,
+]
 
 function carryForward(params: {
   agentId: ObservationAgentId
@@ -30,7 +36,11 @@ function carryForward(params: {
   availability: SnapshotAvailability
 } {
   const observations = params.current.observations.filter(item => item.game_id === params.gameId)
-  const availability = params.current.game_states[params.gameId]
+  const currentAvailability = params.current.game_states[params.gameId]
+  const availability = {
+    ...currentAvailability,
+    observation_count: observations.length,
+  }
   if (observations.length || !params.previous || !['missing', 'degraded'].includes(availability.state)) {
     return { observations, availability }
   }
@@ -87,7 +97,10 @@ export async function runActiveWeekIngestion(params: {
       fetch: params.fetch ?? fetch,
     }
     const feeds = await Promise.all(PROVIDERS.map(provider => provider.collect(context)))
-    const feedByAgent = new Map(PROVIDERS.map((provider, index) => [provider.agentId, feeds[index]]))
+    const feedByAgent = new Map<ObservationAgentId, IngestionFeedResult>()
+    PROVIDERS.forEach((provider, index) => {
+      provider.agentIds.forEach(agentId => feedByAgent.set(agentId, feeds[index]))
+    })
     const capturedAt = new Date().toISOString()
     const snapshots: GameSnapshot[] = []
 
@@ -102,7 +115,23 @@ export async function runActiveWeekIngestion(params: {
       const epa = carryForward({
         agentId: 'epa', current: feedByAgent.get('epa')!, previous, gameId: scheduledGame.game_id,
       })
-      const observations = [...weather.observations, ...injury.observations, ...epa.observations]
+      const trenches = carryForward({
+        agentId: 'trenches', current: feedByAgent.get('trenches')!, previous, gameId: scheduledGame.game_id,
+      })
+      const turnovers = carryForward({
+        agentId: 'turnovers', current: feedByAgent.get('turnovers')!, previous, gameId: scheduledGame.game_id,
+      })
+      const rest = carryForward({
+        agentId: 'rest', current: feedByAgent.get('rest')!, previous, gameId: scheduledGame.game_id,
+      })
+      const observations = [
+        ...weather.observations,
+        ...injury.observations,
+        ...epa.observations,
+        ...trenches.observations,
+        ...turnovers.observations,
+        ...rest.observations,
+      ]
         .sort((left, right) => left.observation_id.localeCompare(right.observation_id))
       const game = GameSchema.parse(scheduledGame)
       const snapshotContent = {
@@ -112,6 +141,9 @@ export async function runActiveWeekIngestion(params: {
           weather: weather.availability,
           injury: injury.availability,
           epa: epa.availability,
+          trenches: trenches.availability,
+          turnovers: turnovers.availability,
+          rest: rest.availability,
         },
       }
       const hash = contentHash(snapshotContent)

--- a/lib/data/providers/nflverse.ts
+++ b/lib/data/providers/nflverse.ts
@@ -83,7 +83,7 @@ function failedFeed(params: {
 }
 
 export const nflverseInjuryProvider: ObservationProvider = {
-  agentId: 'injury',
+  agentIds: ['injury'],
   async collect(context): Promise<IngestionFeedResult> {
     const checkedAt = context.now.toISOString()
     const url = `${NFLVERSE_RELEASE_ROOT}/injuries/injuries_${context.season}.csv`
@@ -190,37 +190,130 @@ type TeamPerformance = {
   plays: number
   offensiveEpa: number
   offensiveEpaPerPlay: number
+  passingAttempts: number
+  dropbacks: number
+  carries: number
+  passingInterceptions: number
+  fumblesLost: number
+  giveawaysPerGame: number
+  interceptionRate: number
+  defensiveInterceptions: number
+  opponentFumbleRecoveries: number
+  takeawaysPerGame: number
+  defensiveForcedFumbles: number
+  sacksSuffered: number
+  sackRateAllowed: number
+  rushingEpa: number
+  rushingEpaPerCarry: number
+  defensiveSacks: number
+  defensiveQbHits: number
+  disruptionPerGame: number
+  defensiveTacklesForLoss: number
+  tacklesForLossPerGame: number
 }
 
+type TeamPerformanceTotal = Omit<TeamPerformance,
+  | 'team'
+  | 'offensiveEpaPerPlay'
+  | 'giveawaysPerGame'
+  | 'interceptionRate'
+  | 'takeawaysPerGame'
+  | 'sackRateAllowed'
+  | 'rushingEpaPerCarry'
+  | 'disruptionPerGame'
+  | 'tacklesForLossPerGame'
+>
+
 function aggregateTeamPerformance(rows: CsvRow[], season: number, beforeWeek?: number): TeamPerformance[] {
-  const totals = new Map<TeamCode, Omit<TeamPerformance, 'team' | 'offensiveEpaPerPlay'>>()
+  const totals = new Map<TeamCode, TeamPerformanceTotal>()
   for (const row of rows) {
     if (Number(row.season) !== season) continue
     if (beforeWeek !== undefined && Number(row.week) >= beforeWeek) continue
+    if (row.season_type && row.season_type !== 'REG') continue
     const team = normalizeTeamCode(row.team)
     if (!team) continue
-    const current = totals.get(team) ?? { games: 0, plays: 0, offensiveEpa: 0 }
+    const current = totals.get(team) ?? {
+      games: 0,
+      plays: 0,
+      offensiveEpa: 0,
+      passingAttempts: 0,
+      dropbacks: 0,
+      carries: 0,
+      passingInterceptions: 0,
+      fumblesLost: 0,
+      defensiveInterceptions: 0,
+      opponentFumbleRecoveries: 0,
+      defensiveForcedFumbles: 0,
+      sacksSuffered: 0,
+      rushingEpa: 0,
+      defensiveSacks: 0,
+      defensiveQbHits: 0,
+      defensiveTacklesForLoss: 0,
+    }
+    const attempts = numeric(row.attempts)
+    const carries = numeric(row.carries)
+    const sacksSuffered = numeric(row.sacks_suffered)
     current.games += numeric(row.games) || 1
-    current.plays += numeric(row.attempts) + numeric(row.carries) + numeric(row.sacks_suffered)
+    current.plays += attempts + carries + sacksSuffered
     current.offensiveEpa += numeric(row.passing_epa) + numeric(row.rushing_epa)
+    current.passingAttempts += attempts
+    current.dropbacks += attempts + sacksSuffered
+    current.carries += carries
+    current.passingInterceptions += numeric(row.passing_interceptions)
+    current.fumblesLost += numeric(row.fumbles_lost_total)
+    current.defensiveInterceptions += numeric(row.def_interceptions)
+    current.opponentFumbleRecoveries += numeric(row.fumble_recovery_opp)
+    current.defensiveForcedFumbles += numeric(row.def_fumbles_forced)
+    current.sacksSuffered += sacksSuffered
+    current.rushingEpa += numeric(row.rushing_epa)
+    current.defensiveSacks += numeric(row.def_sacks)
+    current.defensiveQbHits += numeric(row.def_qb_hits)
+    current.defensiveTacklesForLoss += numeric(row.def_tackles_for_loss)
     totals.set(team, current)
   }
   return [...totals.entries()].map(([team, total]) => ({
     team,
     ...total,
     offensiveEpaPerPlay: total.plays ? total.offensiveEpa / total.plays : 0,
+    giveawaysPerGame: total.games
+      ? (total.passingInterceptions + total.fumblesLost) / total.games
+      : 0,
+    interceptionRate: total.passingAttempts
+      ? total.passingInterceptions / total.passingAttempts
+      : 0,
+    takeawaysPerGame: total.games
+      ? (total.defensiveInterceptions + total.opponentFumbleRecoveries) / total.games
+      : 0,
+    sackRateAllowed: total.dropbacks ? total.sacksSuffered / total.dropbacks : 0,
+    rushingEpaPerCarry: total.carries ? total.rushingEpa / total.carries : 0,
+    disruptionPerGame: total.games
+      ? (total.defensiveSacks + total.defensiveQbHits) / total.games
+      : 0,
+    tacklesForLossPerGame: total.games
+      ? total.defensiveTacklesForLoss / total.games
+      : 0,
   }))
 }
 
-export const nflverseEpaProvider: ObservationProvider = {
-  agentId: 'epa',
+function rankBy(
+  performance: TeamPerformance[],
+  team: TeamCode,
+  value: (candidate: TeamPerformance) => number,
+  direction: 'ascending' | 'descending',
+): number {
+  const ranked = [...performance].sort((left, right) => (
+    direction === 'ascending' ? value(left) - value(right) : value(right) - value(left)
+  ))
+  return ranked.findIndex(candidate => candidate.team === team) + 1
+}
+
+export const nflverseTeamStatsProvider: ObservationProvider = {
+  agentIds: ['epa', 'turnovers', 'trenches'],
   async collect(context): Promise<IngestionFeedResult> {
     const checkedAt = context.now.toISOString()
     const useCurrentSeason = context.week > 1
     const dataSeason = useCurrentSeason ? context.season : context.season - 1
-    const file = useCurrentSeason
-      ? `stats_team_week_${dataSeason}.csv`
-      : `stats_team_reg_${dataSeason}.csv`
+    const file = `stats_team_week_${dataSeason}.csv`
     const url = `${NFLVERSE_RELEASE_ROOT}/stats_team/${file}`
     let response: Response
     let rows: CsvRow[]
@@ -236,11 +329,7 @@ export const nflverseEpaProvider: ObservationProvider = {
       })
     }
 
-    const performance = aggregateTeamPerformance(
-      rows,
-      dataSeason,
-      useCurrentSeason ? context.week : undefined,
-    ).sort((left, right) => right.offensiveEpaPerPlay - left.offensiveEpaPerPlay)
+    const performance = aggregateTeamPerformance(rows, dataSeason, useCurrentSeason ? context.week : undefined)
     const rawImport = createRawImport({
       provider: 'nflverse',
       feed: 'team-stats',
@@ -256,7 +345,11 @@ export const nflverseEpaProvider: ObservationProvider = {
       for (const team of [game.away_team, game.home_team]) {
         const teamPerformance = performance.find(candidate => candidate.team === team)
         if (!teamPerformance) continue
-        const rank = performance.findIndex(candidate => candidate.team === team) + 1
+        const shared = {
+          sample_games: teamPerformance.games,
+          data_season: dataSeason,
+          through_week: useCurrentSeason ? context.week - 1 : 'final',
+        }
         observations.push(createObservation({
           gameId: game.game_id,
           agentId: 'epa',
@@ -265,11 +358,9 @@ export const nflverseEpaProvider: ObservationProvider = {
           metric: 'team.offensive_epa_per_play',
           value: {
             value: Number(teamPerformance.offensiveEpaPerPlay.toFixed(4)),
-            rank,
+            rank: rankBy(performance, team, candidate => candidate.offensiveEpaPerPlay, 'descending'),
             league_size: performance.length,
-            sample_games: teamPerformance.games,
-            data_season: dataSeason,
-            through_week: useCurrentSeason ? context.week - 1 : null,
+            ...shared,
           },
           unit: 'epa_per_play',
           source: {
@@ -284,19 +375,83 @@ export const nflverseEpaProvider: ObservationProvider = {
           expiresAt: new Date(context.now.getTime() + 7 * 24 * 60 * 60 * 1000).toISOString(),
           importedAt: checkedAt,
           rawImportId: rawImport.raw_import_id,
-          providerRecordId: `${dataSeason}:${team}:${useCurrentSeason ? context.week - 1 : 'final'}`,
+          providerRecordId: `${dataSeason}:${team}:${useCurrentSeason ? context.week - 1 : 'final'}:epa`,
         }))
-        gameCounts.set(game.game_id, (gameCounts.get(game.game_id) ?? 0) + 1)
+        observations.push(createObservation({
+          gameId: game.game_id,
+          agentId: 'turnovers',
+          kind: 'measurement',
+          subject: { type: 'team', id: team, label: team, team },
+          metric: 'team.turnover_profile',
+          value: {
+            giveaways_per_game: Number(teamPerformance.giveawaysPerGame.toFixed(3)),
+            giveaway_rank: rankBy(performance, team, candidate => candidate.giveawaysPerGame, 'ascending'),
+            interception_rate: Number(teamPerformance.interceptionRate.toFixed(4)),
+            fumbles_lost: teamPerformance.fumblesLost,
+            takeaways_per_game: Number(teamPerformance.takeawaysPerGame.toFixed(3)),
+            takeaway_rank: rankBy(performance, team, candidate => candidate.takeawaysPerGame, 'descending'),
+            forced_fumbles_per_game: Number((teamPerformance.defensiveForcedFumbles / teamPerformance.games).toFixed(3)),
+            league_size: performance.length,
+            ...shared,
+          },
+          source: {
+            provider: 'nflverse',
+            feed: 'team-stats',
+            quality: 'research',
+            source_url: url,
+            terms_url: NFLVERSE_TERMS_URL,
+          },
+          observedAt,
+          effectiveAt: observedAt,
+          expiresAt: new Date(context.now.getTime() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+          importedAt: checkedAt,
+          rawImportId: rawImport.raw_import_id,
+          providerRecordId: `${dataSeason}:${team}:${useCurrentSeason ? context.week - 1 : 'final'}:turnovers`,
+        }))
+        observations.push(createObservation({
+          gameId: game.game_id,
+          agentId: 'trenches',
+          kind: 'measurement',
+          subject: { type: 'team', id: team, label: team, team },
+          metric: 'team.trenches_proxy',
+          value: {
+            sack_rate_allowed: Number(teamPerformance.sackRateAllowed.toFixed(4)),
+            pass_protection_rank: rankBy(performance, team, candidate => candidate.sackRateAllowed, 'ascending'),
+            rushing_epa_per_carry: Number(teamPerformance.rushingEpaPerCarry.toFixed(4)),
+            rushing_efficiency_rank: rankBy(performance, team, candidate => candidate.rushingEpaPerCarry, 'descending'),
+            defensive_disruptions_per_game: Number(teamPerformance.disruptionPerGame.toFixed(3)),
+            front_disruption_rank: rankBy(performance, team, candidate => candidate.disruptionPerGame, 'descending'),
+            tackles_for_loss_per_game: Number(teamPerformance.tacklesForLossPerGame.toFixed(3)),
+            run_disruption_rank: rankBy(performance, team, candidate => candidate.tacklesForLossPerGame, 'descending'),
+            proxy: true,
+            league_size: performance.length,
+            ...shared,
+          },
+          source: {
+            provider: 'nflverse',
+            feed: 'team-stats',
+            quality: 'research',
+            source_url: url,
+            terms_url: NFLVERSE_TERMS_URL,
+          },
+          observedAt,
+          effectiveAt: observedAt,
+          expiresAt: new Date(context.now.getTime() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+          importedAt: checkedAt,
+          rawImportId: rawImport.raw_import_id,
+          providerRecordId: `${dataSeason}:${team}:${useCurrentSeason ? context.week - 1 : 'final'}:trenches`,
+        }))
+        gameCounts.set(game.game_id, (gameCounts.get(game.game_id) ?? 0) + 3)
       }
     }
 
     const gameStates = Object.fromEntries(context.games.map(game => {
       const count = gameCounts.get(game.game_id) ?? 0
       return [game.game_id, availability({
-        state: count === 2 ? 'available' : count ? 'degraded' : 'missing',
+        state: count === 6 ? 'available' : count ? 'degraded' : 'missing',
         checkedAt,
         count,
-        ...(count !== 2 ? { message: 'A two-team performance baseline is incomplete' } : {}),
+        ...(count !== 6 ? { message: 'A two-team performance baseline is incomplete' } : {}),
       })]
     }))
 

--- a/lib/data/providers/nws.ts
+++ b/lib/data/providers/nws.ts
@@ -191,7 +191,7 @@ async function collectGameWeather(
 }
 
 export const nwsWeatherProvider: ObservationProvider = {
-  agentId: 'weather',
+  agentIds: ['weather'],
   async collect(context): Promise<IngestionFeedResult> {
     const results = await Promise.all(context.games.map((_, index) => collectGameWeather(context, index)))
     const observations = results.flatMap(result => result.observations)

--- a/lib/data/providers/rest.ts
+++ b/lib/data/providers/rest.ts
@@ -1,0 +1,226 @@
+import {
+  GameSnapshotSchema,
+  IngestionFeedResultSchema,
+  OBSERVATION_AGENT_IDS,
+  OBSERVATION_CONTRACT_VERSION,
+  type GameSnapshot,
+  type IngestionFeedResult,
+  type Observation,
+  type SnapshotAvailability,
+} from '@/lib/data/contracts'
+import { contentHash, stableId } from '@/lib/data/hash'
+import { createObservation, createRawImport } from '@/lib/data/providers/shared'
+import type { ObservationProvider, WeekProviderContext } from '@/lib/data/providers/types'
+import { loadSeasonGames, type ScheduleGame } from '@/lib/nfl/schedule'
+import type { TeamCode } from '@/lib/nfl/teams'
+import { getVenueWeatherProfile } from '@/lib/nfl/venues'
+
+const EARTH_RADIUS_MILES = 3958.8
+
+export type TeamRestContext = {
+  team: TeamCode
+  previous_game_id: string | null
+  previous_kickoff: string | null
+  turnaround_hours: number | null
+  turnaround_days: number | null
+  schedule_spot: 'opening_week' | 'short_week' | 'standard' | 'extended_rest'
+  current_site: 'home' | 'away' | 'neutral'
+  consecutive_road_games: boolean
+  travel_miles_from_home: number | null
+  data_scope: 'regular_season_schedule'
+}
+
+function availability(checkedAt: string, count: number): SnapshotAvailability {
+  return {
+    state: count === 2 ? 'available' : count ? 'degraded' : 'missing',
+    checked_at: checkedAt,
+    observation_count: count,
+    ...(count !== 2 ? { message: 'Two-team schedule context is incomplete' } : {}),
+  }
+}
+
+function radians(value: number): number {
+  return value * Math.PI / 180
+}
+
+function distanceMiles(
+  left: { latitude: number; longitude: number },
+  right: { latitude: number; longitude: number },
+): number {
+  const latitudeDelta = radians(right.latitude - left.latitude)
+  const longitudeDelta = radians(right.longitude - left.longitude)
+  const latitudeA = radians(left.latitude)
+  const latitudeB = radians(right.latitude)
+  const a = Math.sin(latitudeDelta / 2) ** 2
+    + Math.cos(latitudeA) * Math.cos(latitudeB) * Math.sin(longitudeDelta / 2) ** 2
+  return EARTH_RADIUS_MILES * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+}
+
+function gameIncludesTeam(game: ScheduleGame, team: TeamCode): boolean {
+  return game.away_team === team || game.home_team === team
+}
+
+function isRoadGame(game: ScheduleGame, team: TeamCode): boolean {
+  return game.neutral_site || game.away_team === team
+}
+
+function homeVenue(games: ScheduleGame[], team: TeamCode): string | undefined {
+  return games.find(game => game.home_team === team && !game.neutral_site && game.venue)?.venue
+}
+
+export function deriveTeamRestContext(params: {
+  game: ScheduleGame
+  team: TeamCode
+  seasonGames: ScheduleGame[]
+}): TeamRestContext {
+  const previousGame = params.seasonGames
+    .filter(game => gameIncludesTeam(game, params.team))
+    .filter(game => Date.parse(game.kickoff) < Date.parse(params.game.kickoff))
+    .at(-1)
+  const turnaroundHours = previousGame
+    ? (Date.parse(params.game.kickoff) - Date.parse(previousGame.kickoff)) / (60 * 60 * 1000)
+    : null
+  const scheduleSpot = turnaroundHours === null
+    ? 'opening_week'
+    : turnaroundHours < 6.5 * 24
+      ? 'short_week'
+      : turnaroundHours >= 9.5 * 24
+        ? 'extended_rest'
+        : 'standard'
+  const currentSite = params.game.neutral_site
+    ? 'neutral'
+    : params.game.home_team === params.team
+      ? 'home'
+      : 'away'
+  const baseVenue = homeVenue(params.seasonGames, params.team)
+  const baseLocation = getVenueWeatherProfile(baseVenue)
+  const gameLocation = getVenueWeatherProfile(params.game.venue)
+  const travelMiles = currentSite === 'home'
+    ? 0
+    : baseLocation && gameLocation
+      ? Math.round(distanceMiles(baseLocation, gameLocation))
+      : null
+
+  return {
+    team: params.team,
+    previous_game_id: previousGame?.game_id ?? null,
+    previous_kickoff: previousGame?.kickoff ?? null,
+    turnaround_hours: turnaroundHours === null ? null : Number(turnaroundHours.toFixed(1)),
+    turnaround_days: turnaroundHours === null ? null : Number((turnaroundHours / 24).toFixed(1)),
+    schedule_spot: scheduleSpot,
+    current_site: currentSite,
+    consecutive_road_games: Boolean(previousGame && isRoadGame(previousGame, params.team) && isRoadGame(params.game, params.team)),
+    travel_miles_from_home: travelMiles,
+    data_scope: 'regular_season_schedule',
+  }
+}
+
+export const scheduleRestProvider: ObservationProvider = {
+  agentIds: ['rest'],
+  async collect(context: WeekProviderContext): Promise<IngestionFeedResult> {
+    const checkedAt = context.now.toISOString()
+    const sourceUrl = `https://www.nfl.com/schedules/${context.season}/REG${context.week}/`
+    const seasonGames = loadSeasonGames(context.season)
+    const contexts = context.games.flatMap(game => (
+      [game.away_team, game.home_team].map(team => ({
+        game,
+        context: deriveTeamRestContext({ game, team, seasonGames }),
+      }))
+    ))
+    const rawImport = createRawImport({
+      provider: 'swantail',
+      feed: 'schedule-derived-rest',
+      sourceUrl,
+      fetchedAt: checkedAt,
+      payload: contexts.map(item => ({ game_id: item.game.game_id, ...item.context })),
+    })
+    const observations: Observation[] = contexts.map(item => createObservation({
+      gameId: item.game.game_id,
+      agentId: 'rest',
+      kind: 'measurement',
+      subject: {
+        type: 'team',
+        id: item.context.team,
+        label: item.context.team,
+        team: item.context.team,
+      },
+      metric: 'team.schedule_rest_context',
+      value: item.context,
+      source: {
+        provider: 'swantail',
+        feed: 'schedule-derived-rest',
+        quality: 'internal',
+        source_url: sourceUrl,
+      },
+      observedAt: checkedAt,
+      effectiveAt: checkedAt,
+      expiresAt: new Date(Date.parse(item.game.kickoff) + 6 * 60 * 60 * 1000).toISOString(),
+      importedAt: checkedAt,
+      rawImportId: rawImport.raw_import_id,
+      providerRecordId: `${item.game.game_id}:${item.context.team}`,
+    }))
+    const gameStates = Object.fromEntries(context.games.map(game => {
+      const count = observations.filter(observation => observation.game_id === game.game_id).length
+      return [game.game_id, availability(checkedAt, count)]
+    }))
+
+    return IngestionFeedResultSchema.parse({
+      provider: 'swantail',
+      feed: 'schedule-derived-rest',
+      state: observations.length ? 'available' : 'missing',
+      checked_at: checkedAt,
+      raw_imports: [rawImport],
+      observations,
+      game_states: gameStates,
+    })
+  },
+}
+
+export async function attachScheduleRestSnapshot(params: {
+  game: ScheduleGame
+  snapshot: GameSnapshot | null
+  now?: Date
+}): Promise<GameSnapshot> {
+  const now = params.now ?? new Date()
+  const feed = await scheduleRestProvider.collect({
+    games: [params.game],
+    season: params.game.season,
+    week: params.game.week,
+    now,
+    fetch,
+  })
+  const restObservations = feed.observations.filter(observation => observation.game_id === params.game.game_id)
+  const observations = [
+    ...(params.snapshot?.observations.filter(observation => observation.agent_id !== 'rest') ?? []),
+    ...restObservations,
+  ].sort((left, right) => left.observation_id.localeCompare(right.observation_id))
+  const missingAvailability = {
+    state: 'missing' as const,
+    checked_at: now.toISOString(),
+    observation_count: 0,
+  }
+  const availability = Object.fromEntries(OBSERVATION_AGENT_IDS.map(agentId => [
+    agentId,
+    agentId === 'rest'
+      ? feed.game_states[params.game.game_id]
+      : params.snapshot?.availability[agentId] ?? missingAvailability,
+  ])) as GameSnapshot['availability']
+  const snapshotContent = {
+    game: params.snapshot?.game ?? params.game,
+    observations,
+    availability,
+  }
+  const hash = contentHash(snapshotContent)
+  return GameSnapshotSchema.parse({
+    snapshot_id: stableId('snapshot', {
+      game_id: params.game.game_id,
+      source: 'schedule-rest-fallback',
+      content_hash: hash,
+    }),
+    game_id: params.game.game_id,
+    captured_at: now.toISOString(),
+    contract_version: OBSERVATION_CONTRACT_VERSION,
+    ...snapshotContent,
+    content_hash: hash,
+  })
+}

--- a/lib/data/providers/types.ts
+++ b/lib/data/providers/types.ts
@@ -16,6 +16,6 @@ export type WeekProviderContext = {
 }
 
 export type ObservationProvider = {
-  agentId: ObservationAgentId
+  agentIds: readonly ObservationAgentId[]
   collect(context: WeekProviderContext): Promise<IngestionFeedResult>
 }

--- a/lib/data/repository.ts
+++ b/lib/data/repository.ts
@@ -179,7 +179,9 @@ export async function loadScenarioRevision(revisionId: string): Promise<Scenario
     where scenario_revision_id = ${revisionId}
     limit 1
   `
-  return rows[0] ? ScenarioResolutionSchema.parse(rows[0].payload) : null
+  if (!rows[0]) return null
+  const parsed = ScenarioResolutionSchema.safeParse(rows[0].payload)
+  return parsed.success ? parsed.data : null
 }
 
 export async function persistScript(params: {

--- a/lib/nfl/schedule.ts
+++ b/lib/nfl/schedule.ts
@@ -83,6 +83,18 @@ function listSeasonScheduleYears(): number[] {
     .sort((left, right) => left - right)
 }
 
+function readSeasonSchedule(season: number): SeasonSchedule {
+  const schedulePath = path.join(SCHEDULES_ROOT, `${season}.json`)
+  if (!existsSync(schedulePath)) {
+    throw new ScheduleNotFoundError(`No regular-season schedule found for ${season}`)
+  }
+  const schedule = SeasonScheduleSchema.parse(JSON.parse(readFileSync(schedulePath, 'utf8')))
+  if (schedule.season !== season) {
+    throw new Error(`Schedule metadata does not match filename: ${season}.json`)
+  }
+  return schedule
+}
+
 function formatEasternTime(kickoff: string): string {
   const date = new Date(kickoff)
   const weekday = new Intl.DateTimeFormat('en-US', {
@@ -166,15 +178,10 @@ export function loadSchedule(params: {
   now?: Date
 } = {}): LoadedSchedule {
   const season = params.season ?? listSeasonScheduleYears().at(-1)
-  const schedulePath = season === undefined ? '' : path.join(SCHEDULES_ROOT, `${season}.json`)
-  if (season === undefined || !existsSync(schedulePath)) {
+  if (season === undefined) {
     throw new ScheduleNotFoundError(`No regular-season schedule found for ${season ?? 'the requested season'}`)
   }
-
-  const schedule = SeasonScheduleSchema.parse(JSON.parse(readFileSync(schedulePath, 'utf8')))
-  if (schedule.season !== season) {
-    throw new Error(`Schedule metadata does not match filename: ${season}.json`)
-  }
+  const schedule = readSeasonSchedule(season)
 
   const selectedWeek = params.week ?? priorityWeek(schedule, params.now ?? new Date())
   const weekGames = schedule.games
@@ -210,6 +217,24 @@ export function loadSchedule(params: {
     availableWeeks: [...new Set(schedule.games.map(game => game.week))].sort((a, b) => a - b),
     totalSeasonGames: schedule.games.length,
   }
+}
+
+export function loadSeasonGames(season: number): ScheduleGame[] {
+  const schedule = readSeasonSchedule(season)
+  return schedule.games
+    .map(game => toScheduleGame({
+      season,
+      week: game.week,
+      awayTeam: game.away_team,
+      homeTeam: game.home_team,
+      kickoff: game.kickoff,
+      neutralSite: game.neutral_site,
+      status: game.status,
+      venue: game.venue,
+      externalId: game.external_id,
+      broadcast: game.broadcast,
+    }))
+    .sort((left, right) => Date.parse(left.kickoff) - Date.parse(right.kickoff))
 }
 
 export function loadOperationalSchedule(params: { now?: Date } = {}): LoadedSchedule {

--- a/lib/terminal/contracts.ts
+++ b/lib/terminal/contracts.ts
@@ -1,79 +1,116 @@
 import { z } from 'zod'
 import { ObservationSchema } from '@/lib/data/contracts'
 
-export const TERMINAL_CONTRACT_VERSION = 'game-script-v2'
+export const TERMINAL_CONTRACT_VERSION = 'game-script-v5'
 
 export const GAME_AGENT_IDS = [
   'weather',
-  'pressure',
+  'momentum',
   'pace',
   'injury',
   'epa',
+  'pressure',
+  'trenches',
+  'turnovers',
   'qb',
-  'hb',
-  'wr',
-  'te',
-  'usage',
+  'rest',
 ] as const
 
 export const GameAgentIdSchema = z.enum(GAME_AGENT_IDS)
 
 export type GameAgentId = z.infer<typeof GameAgentIdSchema>
 
-export const GAME_AGENT_CATALOG: Record<GameAgentId, {
+export type GameAgentDataSupport = 'pilot_observations' | 'assumption_only'
+
+export type GameAgentCatalogEntry = {
   label: string
   shortLabel: string
+  question: string
   description: string
-}> = {
+  dataSupport: GameAgentDataSupport
+  specPath: `docs/agents/${string}.md`
+}
+
+export const GAME_AGENT_CATALOG: Record<GameAgentId, GameAgentCatalogEntry> = {
   weather: {
     label: 'Weather',
     shortLabel: 'WX',
-    description: 'Conditions constrain efficiency and play calling.',
+    question: 'Do kickoff conditions remove or weaken either team\'s preferred way to play?',
+    description: 'Cross-matches wind, precipitation, temperature, and roof state with passing depth, kicking, ball security, and offensive exposure.',
+    dataSupport: 'pilot_observations',
+    specPath: 'docs/agents/weather.md',
   },
-  pressure: {
-    label: 'Pressure',
-    shortLabel: 'PR',
-    description: 'Pass rush disrupts timing and drive success.',
+  momentum: {
+    label: 'Momentum',
+    shortLabel: 'MOM',
+    question: 'Has recent opponent-adjusted execution changed enough to carry into this matchup?',
+    description: 'Separates durable changes in efficiency, personnel, or scheme from streaks driven by schedule and unstable results.',
+    dataSupport: 'assumption_only',
+    specPath: 'docs/agents/momentum.md',
   },
   pace: {
     label: 'Pace',
     shortLabel: 'PC',
-    description: 'Tempo changes play volume and scoring chances.',
+    question: 'Which offense can control play volume, clock pressure, and possession count?',
+    description: 'Uses neutral tempo, no-huddle rate, pass rate, and drive length to frame how many plays each side can access.',
+    dataSupport: 'assumption_only',
+    specPath: 'docs/agents/pace.md',
   },
   injury: {
     label: 'Injuries',
     shortLabel: 'IN',
-    description: 'Availability changes roles and team efficiency.',
+    question: 'Which availability change removes a function the replacement or scheme cannot preserve?',
+    description: 'Measures role loss and replacement quality, then traces redistributed snaps, touches, protection, or coverage.',
+    dataSupport: 'pilot_observations',
+    specPath: 'docs/agents/injuries.md',
   },
   epa: {
     label: 'Efficiency',
     shortLabel: 'EPA',
-    description: 'An efficiency mismatch shapes possession value.',
+    question: 'Where does offensive efficiency collide with the opposing defense\'s ability to suppress it?',
+    description: 'Cross-matches EPA, success rate, explosives, and drive finishing by pass and run to find repeatable advantages.',
+    dataSupport: 'pilot_observations',
+    specPath: 'docs/agents/efficiency-epa.md',
+  },
+  pressure: {
+    label: 'Pressure',
+    shortLabel: 'PR',
+    question: 'Can either pass rush disrupt the quarterback before the offense reaches its answers?',
+    description: 'Cross-matches pressure creation, protection, time to throw, sack avoidance, and quarterback response under pressure.',
+    dataSupport: 'assumption_only',
+    specPath: 'docs/agents/pressure.md',
+  },
+  trenches: {
+    label: 'Trenches',
+    shortLabel: 'OL/DL',
+    question: 'Which offensive line wins or loses its matchup with the opposing defensive line?',
+    description: 'Compares pass protection, pressure, run blocking, and disruption rankings to identify each line-matchup edge.',
+    dataSupport: 'pilot_observations',
+    specPath: 'docs/agents/trenches.md',
+  },
+  turnovers: {
+    label: 'Turnovers',
+    shortLabel: 'TO',
+    question: 'Does one offense\'s ball-risk profile collide with repeatable takeaway creation?',
+    description: 'Cross-matches interceptions, fumbles, sacks, and defensive disruption while discounting recovery luck.',
+    dataSupport: 'pilot_observations',
+    specPath: 'docs/agents/turnovers.md',
   },
   qb: {
     label: 'Quarterback',
     shortLabel: 'QB',
-    description: 'Quarterback play becomes the central game driver.',
+    question: 'Which quarterback can solve this specific coverage, pressure, and down-and-distance environment?',
+    description: 'Profiles accuracy, decisions, depth, mobility, sack avoidance, and performance by pocket and coverage state.',
+    dataSupport: 'assumption_only',
+    specPath: 'docs/agents/quarterback.md',
   },
-  hb: {
-    label: 'Backfield',
-    shortLabel: 'HB',
-    description: 'Rushing volume and control shape the game.',
-  },
-  wr: {
-    label: 'Receivers',
-    shortLabel: 'WR',
-    description: 'Target concentration drives explosive plays.',
-  },
-  te: {
-    label: 'Tight Ends',
-    shortLabel: 'TE',
-    description: 'Middle-field and red-zone usage create leverage.',
-  },
-  usage: {
-    label: 'Usage',
-    shortLabel: 'USG',
-    description: 'Role concentration determines who captures volume.',
+  rest: {
+    label: 'Rest / Travel',
+    shortLabel: 'RST',
+    question: 'Does turnaround, travel, time-zone change, or workload modify a real football matchup?',
+    description: 'Compares recovery windows, travel burden, road sequencing, and snap load without treating rest as a standalone edge.',
+    dataSupport: 'pilot_observations',
+    specPath: 'docs/agents/rest-travel.md',
   },
 }
 
@@ -87,6 +124,7 @@ export const SCENARIO_ANCHOR_IDS = [
   'shootout',
   'grind',
   'blowout',
+  'high_variance',
   'pass_heavy',
   'run_heavy',
 ] as const
@@ -112,12 +150,32 @@ export const ScenarioAnchorSchema = z.object({
   exclusive_group: z.string().min(1),
 })
 
+export const AgentSignalSchema = z.object({
+  label: z.string().min(1),
+  value: z.string().min(1).optional(),
+  away_value: z.string().min(1).optional(),
+  home_value: z.string().min(1).optional(),
+  observation_ids: z.array(z.string().min(1)),
+}).refine(signal => Boolean(signal.value || signal.away_value || signal.home_value), {
+  message: 'An agent signal must contain a value',
+})
+
+export const AgentFindingSchema = z.object({
+  state: z.enum(['material', 'contextual', 'balanced', 'unavailable']),
+  direction: z.enum(['away', 'home', 'none']),
+  headline: z.string().min(1),
+  detail: z.string().min(1),
+  signals: z.array(AgentSignalSchema).max(4),
+  caveats: z.array(z.string().min(1)).max(3),
+})
+
 export const ScenarioEventSchema = z.object({
   id: z.string().min(1),
   agent_id: GameAgentIdSchema,
   label: z.string().min(1),
   assumption: z.string().min(1),
   statement: z.string().min(1),
+  finding: AgentFindingSchema,
   suggested_anchor_ids: z.array(ScenarioAnchorIdSchema),
   evidence_state: z.enum([
     'assumption_only',
@@ -141,7 +199,7 @@ export const ScenarioResolutionSchema = z.object({
   selected_agent_ids: z.array(GameAgentIdSchema).min(1),
   events: z.array(ScenarioEventSchema).min(1),
   anchors: z.array(ScenarioAnchorSchema).min(1),
-  suggested_anchor_ids: z.array(ScenarioAnchorIdSchema).min(1),
+  suggested_anchor_ids: z.array(ScenarioAnchorIdSchema),
   resolved_at: z.string().datetime({ offset: true }),
   evidence_state: z.enum([
     'scenario_assumptions',
@@ -172,7 +230,7 @@ export const GameScriptSchema = z.object({
   parent_script_id: z.string().min(1).optional(),
   title: z.string().min(1),
   summary: z.string().min(1),
-  causal_chain: z.array(CausalStepSchema).min(2).max(8),
+  causal_chain: z.array(CausalStepSchema).min(2).max(GAME_AGENT_IDS.length + 1),
   key_conditions: z.array(z.string().min(1)).min(1).max(6),
   failure_conditions: z.array(z.string().min(1)).min(1).max(6),
   anchor_ids: z.array(ScenarioAnchorIdSchema).min(1),
@@ -201,6 +259,8 @@ export const ScriptEvaluationSchema = z.object({
 
 export type ScenarioGame = z.infer<typeof ScenarioGameSchema>
 export type ScenarioAnchor = z.infer<typeof ScenarioAnchorSchema>
+export type AgentSignal = z.infer<typeof AgentSignalSchema>
+export type AgentFinding = z.infer<typeof AgentFindingSchema>
 export type ScenarioEvent = z.infer<typeof ScenarioEventSchema>
 export type ScenarioResolution = z.infer<typeof ScenarioResolutionSchema>
 export type GameScript = z.infer<typeof GameScriptSchema>

--- a/lib/terminal/evaluate.ts
+++ b/lib/terminal/evaluate.ts
@@ -29,7 +29,10 @@ export function evaluateScript(params: {
   const failureConditionsPresent = params.script.failure_conditions.length > 0
     && params.script.failure_conditions.every(condition => condition.trim().length >= 12)
   const claims = numericClaims(params.script)
-  const evidence = JSON.stringify(params.scenario.events.flatMap(event => event.observations))
+  const evidence = JSON.stringify(params.scenario.events.map(event => ({
+    observations: event.observations,
+    finding: event.finding,
+  })))
   const numericClaimsSourced = claims.every(claim => evidence.includes(claim.replace('%', '')))
   const issues = [
     ...(!selectedAgentsRepresented ? ['Not every selected agent appears in the causal chain'] : []),

--- a/lib/terminal/scenario.ts
+++ b/lib/terminal/scenario.ts
@@ -1,8 +1,14 @@
-import type { GameSnapshot, Observation, SnapshotAvailability } from '@/lib/data/contracts'
+import {
+  ObservationAgentIdSchema,
+  type GameSnapshot,
+  type Observation,
+  type SnapshotAvailability,
+} from '@/lib/data/contracts'
 import { contentHash, stableId } from '@/lib/data/hash'
 import {
   GAME_AGENT_CATALOG,
   GAME_AGENT_IDS,
+  type AgentFinding,
   type GameAgentId,
   type ScenarioAnchor,
   type ScenarioAnchorId,
@@ -15,28 +21,33 @@ import {
 
 const AGENT_ANCHORS: Record<GameAgentId, ScenarioAnchorId[]> = {
   weather: ['game_under', 'grind', 'run_heavy'],
-  pressure: ['game_under', 'grind'],
+  momentum: ['blowout'],
   pace: ['game_over', 'shootout'],
   injury: ['game_under', 'grind'],
   epa: ['blowout'],
+  pressure: ['game_under', 'grind'],
+  trenches: ['run_heavy', 'grind'],
+  turnovers: ['high_variance'],
   qb: ['game_over', 'pass_heavy'],
-  hb: ['run_heavy', 'grind'],
-  wr: ['game_over', 'pass_heavy'],
-  te: ['pass_heavy'],
-  usage: ['pass_heavy'],
+  rest: ['grind'],
 }
+
 const AGENT_EVENTS: Record<GameAgentId, string> = {
-  weather: 'Game conditions suppress clean execution, pushing play calling toward lower-variance outcomes.',
-  pressure: 'Pressure shortens quarterback timing, increasing stalled drives and reducing downfield efficiency.',
-  pace: 'A faster possession cycle creates more plays, more scoring chances, and more paths to volume.',
-  injury: 'Material availability changes redistribute responsibility and lower the margin for failed execution.',
-  epa: 'The stronger efficiency profile compounds across possessions and can create scoreboard separation.',
-  qb: 'Quarterback efficiency becomes the hinge for sustained drives and explosive scoring outcomes.',
-  hb: 'Backfield volume controls possession length and makes rushing success central to the result.',
-  wr: 'Concentrated receiver usage turns passing success into repeatable explosive-play opportunities.',
-  te: 'Middle-field and red-zone access make tight-end involvement a key conversion mechanism.',
-  usage: 'A concentrated role funnels opportunities toward the players most likely to capture game volume.',
+  weather: 'Kickoff conditions interact with each offense\'s passing depth, handling, and kicking profile, potentially narrowing one playbook more than the other.',
+  momentum: 'A durable change in opponent-adjusted execution, personnel, or scheme can reshape the matchup baseline beyond recent wins and losses.',
+  pace: 'Neutral tempo, pass rate, and drive duration determine which offense can impose play volume and possession rhythm.',
+  injury: 'An availability change matters when the replacement or scheme cannot preserve the missing function, forcing roles and responsibilities to move.',
+  epa: 'The offense-versus-defense efficiency cross-match determines whether ordinary play-level success can repeat and compound across drives.',
+  pressure: 'Pass-rush arrival meets protection and quarterback response, determining whether passing concepts develop or drives become fragile.',
+  trenches: 'Each offensive line\'s run blocking and pass protection meet the opposing defensive line\'s pressure and disruption profile.',
+  turnovers: 'Offensive ball risk meets repeatable defensive takeaway creation, creating the possibility of lost possessions and short fields.',
+  qb: 'Quarterback decisions, accuracy, mobility, and sack avoidance meet the matchup\'s coverage, pressure, and down-and-distance demands.',
+  rest: 'Turnaround, travel, and recent workload can modify a specific preparation, personnel, or unit-level matchup.',
 }
+
+type EventEvidence = Pick<ScenarioEvent,
+  'statement' | 'finding' | 'evidence_state' | 'observations' | 'suggested_anchor_ids'
+>
 
 export function createAnchorCatalog(game: ScenarioGame): ScenarioAnchor[] {
   return [
@@ -49,6 +60,7 @@ export function createAnchorCatalog(game: ScenarioGame): ScenarioAnchor[] {
     { id: 'shootout', category: 'shape', label: 'Shootout', exclusive_group: 'shape' },
     { id: 'grind', category: 'shape', label: 'Grind', exclusive_group: 'shape' },
     { id: 'blowout', category: 'shape', label: 'Blowout', exclusive_group: 'shape' },
+    { id: 'high_variance', category: 'shape', label: 'High variance', exclusive_group: 'shape' },
     { id: 'pass_heavy', category: 'style', label: 'Pass-heavy', exclusive_group: 'style' },
     { id: 'run_heavy', category: 'style', label: 'Run-heavy', exclusive_group: 'style' },
   ]
@@ -60,97 +72,460 @@ function recordValue(observation: Observation | undefined): Record<string, unkno
     : {}
 }
 
+function numericValue(record: Record<string, unknown>, key: string): number | null {
+  return typeof record[key] === 'number' && Number.isFinite(record[key]) ? record[key] as number : null
+}
+
+function teamObservation(observations: Observation[], team: string): Observation | undefined {
+  return observations.find(observation => observation.subject.id === team)
+}
+
+function directionForTeam(team: string, game: ScenarioGame): AgentFinding['direction'] {
+  if (team === game.away_team) return 'away'
+  if (team === game.home_team) return 'home'
+  return 'none'
+}
+
+function winnerAnchor(direction: AgentFinding['direction']): ScenarioAnchorId[] {
+  if (direction === 'away') return ['away_win']
+  if (direction === 'home') return ['home_win']
+  return []
+}
+
+function rankStrength(rank: number | null, leagueSize: number | null): number {
+  if (rank === null || leagueSize === null || leagueSize <= 1) return 0.5
+  return (leagueSize - rank) / (leagueSize - 1)
+}
+
+function rankLabel(rank: number | null, leagueSize: number | null): string {
+  return rank === null ? 'unavailable' : `#${rank}${leagueSize ? ` of ${leagueSize}` : ''}`
+}
+
+function priorSeasonCaveat(observations: Observation[], game: ScenarioGame): string[] {
+  const dataSeason = numericValue(recordValue(observations[0]), 'data_season')
+  return dataSeason !== null && dataSeason !== game.season
+    ? [`Uses the ${dataSeason} regular season as an explicitly labeled Week 1 baseline.`]
+    : []
+}
+
+function unavailableEvidence(params: {
+  agentId: GameAgentId
+  statement: string
+  evidenceState: ScenarioEvent['evidence_state']
+  observations?: Observation[]
+  caveat: string
+}): EventEvidence {
+  return {
+    statement: params.statement,
+    finding: {
+      state: 'unavailable',
+      direction: 'none',
+      headline: `${GAME_AGENT_CATALOG[params.agentId].label} does not have a current matchup finding`,
+      detail: params.statement,
+      signals: [],
+      caveats: [params.caveat],
+    },
+    evidence_state: params.evidenceState,
+    observations: params.observations ?? [],
+    suggested_anchor_ids: params.evidenceState === 'assumption_only' ? AGENT_ANCHORS[params.agentId] : [],
+  }
+}
+
+function weatherEvidence(observations: Observation[]): EventEvidence {
+  const value = recordValue(observations[0])
+  const wind = numericValue(value, 'wind_mph')
+  const precipitation = numericValue(value, 'precipitation_probability')
+  const summary = typeof value.summary === 'string' ? value.summary : 'available conditions'
+  const detail = [
+    wind !== null ? `${wind} mph wind` : null,
+    precipitation !== null ? `${precipitation}% precipitation probability` : null,
+    summary,
+  ].filter(Boolean).join(', ')
+  const suppressive = (wind ?? 0) >= 15 || (precipitation ?? 0) >= 40
+  const statement = suppressive
+    ? `The kickoff forecast shows ${detail}; those conditions can constrain clean passing and kicking execution.`
+    : `The kickoff forecast shows ${detail}; current conditions do not create a material weather constraint.`
+  return {
+    statement,
+    finding: {
+      state: suppressive ? 'material' : 'balanced',
+      direction: 'none',
+      headline: suppressive ? 'Kickoff weather can narrow the available playbook' : 'Kickoff weather is not a material constraint',
+      detail: statement,
+      signals: [{
+        label: 'Kickoff forecast',
+        value: detail,
+        observation_ids: observations.map(observation => observation.observation_id),
+      }],
+      caveats: ['Forecast conditions can change before kickoff.'],
+    },
+    evidence_state: suppressive ? 'observed_support' : 'observed_context',
+    observations,
+    suggested_anchor_ids: suppressive ? AGENT_ANCHORS.weather : [],
+  }
+}
+
+function injuryEvidence(observations: Observation[]): EventEvidence {
+  const material = observations.filter(observation => {
+    const status = String(recordValue(observation).report_status ?? '').toLowerCase()
+    return ['out', 'doubtful', 'questionable'].includes(status)
+  })
+  const names = material.slice(0, 3).map(observation => observation.subject.label).filter(Boolean)
+  const statement = material.length
+    ? `${material.length} material player availability report${material.length === 1 ? '' : 's'} are attached${names.length ? `, including ${names.join(', ')}` : ''}; their role effects still require matchup context.`
+    : 'Current reports contain practice or contextual statuses, but no material game designation.'
+  return {
+    statement,
+    finding: {
+      state: material.length ? 'material' : 'balanced',
+      direction: 'none',
+      headline: material.length ? 'Availability can redistribute meaningful roles' : 'No material availability designation is attached',
+      detail: statement,
+      signals: [{
+        label: 'Material reports',
+        value: `${material.length} attached`,
+        observation_ids: material.map(observation => observation.observation_id),
+      }],
+      caveats: ['A designation alone does not establish replacement quality or expected workload.'],
+    },
+    evidence_state: material.length ? 'observed_support' : 'observed_context',
+    observations,
+    suggested_anchor_ids: material.length ? AGENT_ANCHORS.injury : [],
+  }
+}
+
+function epaEvidence(observations: Observation[], game: ScenarioGame): EventEvidence | null {
+  const awayObservation = teamObservation(observations, game.away_team)
+  const homeObservation = teamObservation(observations, game.home_team)
+  if (!awayObservation || !homeObservation) return null
+  const away = recordValue(awayObservation)
+  const home = recordValue(homeObservation)
+  const awayRank = numericValue(away, 'rank')
+  const homeRank = numericValue(home, 'rank')
+  if (awayRank === null || homeRank === null) return null
+  const gap = Math.abs(awayRank - homeRank)
+  const strongerTeam = awayRank < homeRank ? game.away_team : game.home_team
+  const direction = directionForTeam(strongerTeam, game)
+  const state: AgentFinding['state'] = gap >= 8 ? 'material' : gap >= 4 ? 'contextual' : 'balanced'
+  const statement = state === 'material'
+    ? `${strongerTeam} owns the stronger offensive EPA baseline by ${gap} ranking positions, creating a repeatable possession-value mechanism.`
+    : `The offensive EPA baselines are separated by ${gap} ranking positions, which is not enough to establish a major efficiency mismatch.`
+  return {
+    statement,
+    finding: {
+      state,
+      direction: state === 'balanced' ? 'none' : direction,
+      headline: state === 'material' ? `${strongerTeam} has the clearer efficiency path` : 'The efficiency profiles are relatively close',
+      detail: statement,
+      signals: [{
+        label: 'Offensive EPA rank',
+        away_value: rankLabel(awayRank, numericValue(away, 'league_size')),
+        home_value: rankLabel(homeRank, numericValue(home, 'league_size')),
+        observation_ids: [awayObservation.observation_id, homeObservation.observation_id],
+      }],
+      caveats: priorSeasonCaveat(observations, game),
+    },
+    evidence_state: state === 'material' ? 'observed_support' : 'observed_context',
+    observations,
+    suggested_anchor_ids: state === 'material' ? [...winnerAnchor(direction), 'blowout'] : [],
+  }
+}
+
+function turnoversEvidence(observations: Observation[], game: ScenarioGame): EventEvidence | null {
+  const awayObservation = teamObservation(observations, game.away_team)
+  const homeObservation = teamObservation(observations, game.home_team)
+  if (!awayObservation || !homeObservation) return null
+  const away = recordValue(awayObservation)
+  const home = recordValue(homeObservation)
+  const leagueSize = numericValue(away, 'league_size') ?? numericValue(home, 'league_size')
+  const awayGiveawayRank = numericValue(away, 'giveaway_rank')
+  const homeGiveawayRank = numericValue(home, 'giveaway_rank')
+  const awayTakeawayRank = numericValue(away, 'takeaway_rank')
+  const homeTakeawayRank = numericValue(home, 'takeaway_rank')
+  const awayRisk = (1 - rankStrength(awayGiveawayRank, leagueSize) + rankStrength(homeTakeawayRank, leagueSize)) / 2
+  const homeRisk = (1 - rankStrength(homeGiveawayRank, leagueSize) + rankStrength(awayTakeawayRank, leagueSize)) / 2
+  const gap = Math.abs(awayRisk - homeRisk)
+  const advantagedTeam = awayRisk < homeRisk ? game.away_team : game.home_team
+  const direction = directionForTeam(advantagedTeam, game)
+  const state: AgentFinding['state'] = gap >= 0.2 ? 'material' : gap >= 0.1 ? 'contextual' : 'balanced'
+  const riskLabel = (risk: number) => risk >= 0.62 ? 'elevated' : risk <= 0.38 ? 'contained' : 'typical'
+  const statement = state === 'material'
+    ? `${advantagedTeam} has the cleaner turnover exchange when each offense's ball security is crossed with the opposing takeaway profile.`
+    : 'The two turnover cross-matches are close enough that variance matters more than a stable team advantage.'
+  return {
+    statement,
+    finding: {
+      state,
+      direction: state === 'balanced' ? 'none' : direction,
+      headline: state === 'material' ? `${advantagedTeam} has the cleaner ball-security matchup` : 'Turnover exposure is broadly balanced',
+      detail: statement,
+      signals: [
+        {
+          label: 'Giveaways / game',
+          away_value: String(numericValue(away, 'giveaways_per_game') ?? 'unavailable'),
+          home_value: String(numericValue(home, 'giveaways_per_game') ?? 'unavailable'),
+          observation_ids: [awayObservation.observation_id, homeObservation.observation_id],
+        },
+        {
+          label: 'Takeaways / game',
+          away_value: String(numericValue(away, 'takeaways_per_game') ?? 'unavailable'),
+          home_value: String(numericValue(home, 'takeaways_per_game') ?? 'unavailable'),
+          observation_ids: [awayObservation.observation_id, homeObservation.observation_id],
+        },
+        {
+          label: 'Cross-match exposure',
+          away_value: riskLabel(awayRisk),
+          home_value: riskLabel(homeRisk),
+          observation_ids: [awayObservation.observation_id, homeObservation.observation_id],
+        },
+      ],
+      caveats: [
+        ...priorSeasonCaveat(observations, game),
+        'Turnover outcomes are noisy; this compares repeatable team profiles rather than projecting a turnover count.',
+      ],
+    },
+    evidence_state: state === 'material' ? 'observed_support' : 'observed_context',
+    observations,
+    suggested_anchor_ids: state === 'material' ? [...winnerAnchor(direction), 'high_variance'] : [],
+  }
+}
+
+function trenchesEvidence(observations: Observation[], game: ScenarioGame): EventEvidence | null {
+  const awayObservation = teamObservation(observations, game.away_team)
+  const homeObservation = teamObservation(observations, game.home_team)
+  if (!awayObservation || !homeObservation) return null
+  const away = recordValue(awayObservation)
+  const home = recordValue(homeObservation)
+  const leagueSize = numericValue(away, 'league_size') ?? numericValue(home, 'league_size')
+  const awayPass = rankStrength(numericValue(away, 'pass_protection_rank'), leagueSize)
+    - rankStrength(numericValue(home, 'front_disruption_rank'), leagueSize)
+  const homePass = rankStrength(numericValue(home, 'pass_protection_rank'), leagueSize)
+    - rankStrength(numericValue(away, 'front_disruption_rank'), leagueSize)
+  const awayRun = rankStrength(numericValue(away, 'rushing_efficiency_rank'), leagueSize)
+    - rankStrength(numericValue(home, 'run_disruption_rank'), leagueSize)
+  const homeRun = rankStrength(numericValue(home, 'rushing_efficiency_rank'), leagueSize)
+    - rankStrength(numericValue(away, 'run_disruption_rank'), leagueSize)
+  const awayControl = (awayPass + awayRun) / 2
+  const homeControl = (homePass + homeRun) / 2
+  const gap = Math.abs(awayControl - homeControl)
+  const advantagedTeam = awayControl > homeControl ? game.away_team : game.home_team
+  const direction = directionForTeam(advantagedTeam, game)
+  const state: AgentFinding['state'] = gap >= 0.2 ? 'material' : gap >= 0.1 ? 'contextual' : 'balanced'
+  const runDriven = Math.abs(awayRun - homeRun) >= Math.abs(awayPass - homePass)
+  const statement = state === 'material'
+    ? `${advantagedTeam} has the stronger result-based line-of-scrimmage cross-match across protection, rushing efficiency, and front disruption.`
+    : 'The result-based protection and front metrics do not establish a major line-of-scrimmage mismatch.'
+  return {
+    statement,
+    finding: {
+      state,
+      direction: state === 'balanced' ? 'none' : direction,
+      headline: state === 'material' ? `${advantagedTeam} has the clearer trench-control path` : 'The trench proxies are relatively balanced',
+      detail: statement,
+      signals: [
+        {
+          label: 'Pass protection rank',
+          away_value: rankLabel(numericValue(away, 'pass_protection_rank'), leagueSize),
+          home_value: rankLabel(numericValue(home, 'pass_protection_rank'), leagueSize),
+          observation_ids: [awayObservation.observation_id, homeObservation.observation_id],
+        },
+        {
+          label: 'Rushing efficiency rank',
+          away_value: rankLabel(numericValue(away, 'rushing_efficiency_rank'), leagueSize),
+          home_value: rankLabel(numericValue(home, 'rushing_efficiency_rank'), leagueSize),
+          observation_ids: [awayObservation.observation_id, homeObservation.observation_id],
+        },
+        {
+          label: 'Front disruption rank',
+          away_value: rankLabel(numericValue(away, 'front_disruption_rank'), leagueSize),
+          home_value: rankLabel(numericValue(home, 'front_disruption_rank'), leagueSize),
+          observation_ids: [awayObservation.observation_id, homeObservation.observation_id],
+        },
+      ],
+      caveats: [
+        ...priorSeasonCaveat(observations, game),
+        'This is a transparent result-based proxy, not an assignment-level offensive-line grade.',
+      ],
+    },
+    evidence_state: state === 'material' ? 'observed_support' : 'observed_context',
+    observations,
+    suggested_anchor_ids: state === 'material'
+      ? [...winnerAnchor(direction), runDriven ? 'run_heavy' : 'pass_heavy']
+      : [],
+  }
+}
+
+function restEvidence(observations: Observation[], game: ScenarioGame): EventEvidence | null {
+  const awayObservation = teamObservation(observations, game.away_team)
+  const homeObservation = teamObservation(observations, game.home_team)
+  if (!awayObservation || !homeObservation) return null
+  const away = recordValue(awayObservation)
+  const home = recordValue(homeObservation)
+  const awayDays = numericValue(away, 'turnaround_days')
+  const homeDays = numericValue(home, 'turnaround_days')
+  const awayTravel = numericValue(away, 'travel_miles_from_home')
+  const homeTravel = numericValue(home, 'travel_miles_from_home')
+  const restGap = awayDays !== null && homeDays !== null ? Math.abs(awayDays - homeDays) : null
+  const advantagedTeam = restGap !== null && restGap > 0
+    ? awayDays! > homeDays! ? game.away_team : game.home_team
+    : null
+  const direction = advantagedTeam ? directionForTeam(advantagedTeam, game) : 'none'
+  const openingWeek = awayDays === null || homeDays === null
+  const state: AgentFinding['state'] = openingWeek
+    ? 'contextual'
+    : restGap! >= 1.5
+      ? 'material'
+      : restGap! >= 0.75
+        ? 'contextual'
+        : 'balanced'
+  const statement = openingWeek
+    ? 'The regular-season schedule establishes travel context, but Week 1 does not have a prior regular-season turnaround baseline.'
+    : state === 'material'
+      ? `${advantagedTeam} has the cleaner recovery and preparation window entering this matchup.`
+      : 'The two teams enter with comparable turnaround windows, so rest is not a standalone matchup edge.'
+  const scheduleSpot = (value: Record<string, unknown>) => (
+    typeof value.schedule_spot === 'string' ? value.schedule_spot.replace(/_/g, ' ') : 'unavailable'
+  )
+  return {
+    statement,
+    finding: {
+      state,
+      direction: state === 'material' ? direction : 'none',
+      headline: openingWeek
+        ? 'Week 1 rest is not established by the regular-season schedule'
+        : state === 'material'
+          ? `${advantagedTeam} has the stronger rest profile`
+          : 'Rest windows are effectively even',
+      detail: statement,
+      signals: [
+        {
+          label: 'Turnaround',
+          away_value: awayDays === null ? 'opening week' : `${awayDays} days`,
+          home_value: homeDays === null ? 'opening week' : `${homeDays} days`,
+          observation_ids: [awayObservation.observation_id, homeObservation.observation_id],
+        },
+        {
+          label: 'Schedule spot',
+          away_value: scheduleSpot(away),
+          home_value: scheduleSpot(home),
+          observation_ids: [awayObservation.observation_id, homeObservation.observation_id],
+        },
+        {
+          label: 'Travel from home',
+          away_value: awayTravel === null ? 'unavailable' : `${Math.round(awayTravel)} mi`,
+          home_value: homeTravel === null ? 'unavailable' : `${Math.round(homeTravel)} mi`,
+          observation_ids: [awayObservation.observation_id, homeObservation.observation_id],
+        },
+      ],
+      caveats: openingWeek
+        ? ['Preseason games are intentionally excluded from the rest calculation.']
+        : ['Schedule-derived rest does not yet include overtime or player snap load.'],
+    },
+    evidence_state: state === 'material' ? 'observed_support' : 'observed_context',
+    observations,
+    suggested_anchor_ids: state === 'material' ? winnerAnchor(direction) : [],
+  }
+}
+
 function eventEvidence(params: {
   agentId: GameAgentId
+  game: ScenarioGame
   observations: Observation[]
   availability?: SnapshotAvailability
   now: Date
-}): Pick<ScenarioEvent, 'statement' | 'evidence_state' | 'observations'> {
+}): EventEvidence {
   const assumption = AGENT_EVENTS[params.agentId]
   if (!params.availability) {
-    return { statement: assumption, evidence_state: 'assumption_only', observations: [] }
+    return unavailableEvidence({
+      agentId: params.agentId,
+      statement: assumption,
+      evidenceState: 'assumption_only',
+      caveat: 'No current observation adapter is configured for this lens.',
+    })
   }
   if (!params.observations.length) {
     const enclosedVenue = params.agentId === 'weather'
       && params.availability.state === 'available'
       && params.availability.message?.startsWith('Enclosed venue')
-    return {
-      statement: enclosedVenue
-        ? `${params.availability.message}; this conflicts with a material exterior weather-suppression scenario.`
-        : `${assumption} No current sourced observation is attached, so this remains a scenario assumption.`,
-      evidence_state: enclosedVenue ? 'observed_conflict' : 'missing',
-      observations: [],
-    }
+    const statement = enclosedVenue
+      ? `${params.availability.message}; exterior weather is not a material game condition.`
+      : `${assumption} No current sourced observation is attached.`
+    return unavailableEvidence({
+      agentId: params.agentId,
+      statement,
+      evidenceState: enclosedVenue ? 'observed_conflict' : 'missing',
+      caveat: params.availability.message ?? 'The current snapshot does not contain this feed.',
+    })
   }
   const allStale = params.observations.every(observation => (
     observation.expires_at && Date.parse(observation.expires_at) <= params.now.getTime()
   ))
   if (allStale) {
-    return {
-      statement: `${assumption} The latest attached observations are stale and should not be treated as current support.`,
-      evidence_state: 'stale',
+    return unavailableEvidence({
+      agentId: params.agentId,
+      statement: `${assumption} The latest attached observations are stale.`,
+      evidenceState: 'stale',
       observations: params.observations,
-    }
-  }
-
-  if (params.agentId === 'weather') {
-    const value = recordValue(params.observations[0])
-    const wind = typeof value.wind_mph === 'number' ? value.wind_mph : null
-    const precipitation = typeof value.precipitation_probability === 'number'
-      ? value.precipitation_probability
-      : null
-    const summary = typeof value.summary === 'string' ? value.summary : 'available conditions'
-    const detail = [
-      wind !== null ? `${wind} mph wind` : null,
-      precipitation !== null ? `${precipitation}% precipitation probability` : null,
-      summary,
-    ].filter(Boolean).join(', ')
-    const suppressive = (wind ?? 0) >= 15 || (precipitation ?? 0) >= 40
-    return {
-      statement: suppressive
-        ? `The NWS kickoff forecast shows ${detail}; those conditions support the selected weather-suppression scenario.`
-        : `The NWS kickoff forecast shows ${detail}; current conditions do not support a material weather-suppression scenario.`,
-      evidence_state: suppressive ? 'observed_support' : 'observed_conflict',
-      observations: params.observations,
-    }
-  }
-
-  if (params.agentId === 'injury') {
-    const material = params.observations.filter(observation => {
-      const status = String(recordValue(observation).report_status ?? '').toLowerCase()
-      return ['out', 'doubtful', 'questionable'].includes(status)
+      caveat: 'Refresh the data snapshot before treating this lens as current.',
     })
-    const names = material.slice(0, 3).map(observation => observation.subject.label).filter(Boolean)
-    return {
-      statement: material.length
-        ? `${material.length} material player availability report${material.length === 1 ? '' : 's'} are attached${names.length ? `, including ${names.join(', ')}` : ''}; role and efficiency changes are a supported scenario input.`
-        : 'Current injury observations contain practice or contextual statuses, but no material game designation supporting the selected injury scenario.',
-      evidence_state: material.length ? 'observed_support' : 'observed_context',
-      observations: params.observations,
-    }
   }
 
+  if (params.agentId === 'weather') return weatherEvidence(params.observations)
+  if (params.agentId === 'injury') return injuryEvidence(params.observations)
   if (params.agentId === 'epa') {
-    const ranked = params.observations
-      .map(observation => ({ observation, value: recordValue(observation) }))
-      .filter(item => typeof item.value.rank === 'number')
-      .sort((left, right) => Number(left.value.rank) - Number(right.value.rank))
-    if (ranked.length >= 2) {
-      const stronger = ranked[0]
-      const weaker = ranked[1]
-      const gap = Number(weaker.value.rank) - Number(stronger.value.rank)
-      return {
-        statement: `${stronger.observation.subject.id} ranks ${stronger.value.rank} and ${weaker.observation.subject.id} ranks ${weaker.value.rank} in the attached offensive EPA-per-play baseline; ${gap >= 8 ? 'the gap supports an efficiency-mismatch scenario' : 'the gap is not large enough to establish a strong mismatch'}.`,
-        evidence_state: gap >= 8 ? 'observed_support' : 'observed_context',
+    return epaEvidence(params.observations, params.game)
+      ?? unavailableEvidence({
+        agentId: params.agentId,
+        statement: 'A complete two-team efficiency comparison is unavailable.',
+        evidenceState: 'missing',
         observations: params.observations,
-      }
-    }
+        caveat: 'Both team baselines are required.',
+      })
+  }
+  if (params.agentId === 'turnovers') {
+    return turnoversEvidence(params.observations, params.game)
+      ?? unavailableEvidence({
+        agentId: params.agentId,
+        statement: 'A complete two-team turnover comparison is unavailable.',
+        evidenceState: 'missing',
+        observations: params.observations,
+        caveat: 'Both team turnover profiles are required.',
+      })
+  }
+  if (params.agentId === 'trenches') {
+    return trenchesEvidence(params.observations, params.game)
+      ?? unavailableEvidence({
+        agentId: params.agentId,
+        statement: 'A complete two-team trenches comparison is unavailable.',
+        evidenceState: 'missing',
+        observations: params.observations,
+        caveat: 'Both team proxy profiles are required.',
+      })
+  }
+  if (params.agentId === 'rest') {
+    return restEvidence(params.observations, params.game)
+      ?? unavailableEvidence({
+        agentId: params.agentId,
+        statement: 'A complete two-team rest comparison is unavailable.',
+        evidenceState: 'missing',
+        observations: params.observations,
+        caveat: 'Both team schedule contexts are required.',
+      })
   }
 
   return {
     statement: assumption,
+    finding: {
+      state: 'contextual',
+      direction: 'none',
+      headline: `${GAME_AGENT_CATALOG[params.agentId].label} has sourced context`,
+      detail: assumption,
+      signals: [],
+      caveats: [],
+    },
     evidence_state: 'observed_context',
     observations: params.observations,
+    suggested_anchor_ids: [],
   }
 }
 
@@ -165,14 +540,13 @@ function scenarioEvidenceState(events: ScenarioEvent[]): ScenarioResolution['evi
   return 'observations_available'
 }
 
-export function suggestAnchors(agentIds: GameAgentId[], anchors: ScenarioAnchor[]): ScenarioAnchorId[] {
+export function suggestAnchors(events: ScenarioEvent[], anchors: ScenarioAnchor[]): ScenarioAnchorId[] {
   const scores = new Map<ScenarioAnchorId, number>()
   const firstSeen = new Map<ScenarioAnchorId, number>()
   let sequence = 0
 
-  for (const agentId of GAME_AGENT_IDS) {
-    if (!agentIds.includes(agentId)) continue
-    for (const anchorId of AGENT_ANCHORS[agentId]) {
+  for (const event of events) {
+    for (const anchorId of event.suggested_anchor_ids) {
       scores.set(anchorId, (scores.get(anchorId) ?? 0) + 1)
       if (!firstSeen.has(anchorId)) firstSeen.set(anchorId, sequence++)
     }
@@ -215,16 +589,16 @@ export function resolveScenario(params: {
   })
   const events: ScenarioEvent[] = selectedAgentIds.map(agentId => {
     const observations = params.snapshot?.observations.filter(item => item.agent_id === agentId) ?? []
-    const availability = params.snapshot && ['weather', 'injury', 'epa'].includes(agentId)
-      ? params.snapshot.availability[agentId as keyof GameSnapshot['availability']]
+    const observedAgent = ObservationAgentIdSchema.safeParse(agentId)
+    const availability = params.snapshot && observedAgent.success
+      ? params.snapshot.availability[observedAgent.data]
       : undefined
     return {
       id: stableId('event', { game_id: params.game.game_id, agent_id: agentId, snapshot_id: snapshotId }),
       agent_id: agentId,
       label: GAME_AGENT_CATALOG[agentId].label,
       assumption: AGENT_EVENTS[agentId],
-      ...eventEvidence({ agentId, observations, availability, now }),
-      suggested_anchor_ids: AGENT_ANCHORS[agentId],
+      ...eventEvidence({ agentId, game: params.game, observations, availability, now }),
     }
   })
   const scenarioId = stableId('scenario', {
@@ -249,7 +623,7 @@ export function resolveScenario(params: {
     selected_agent_ids: selectedAgentIds,
     events,
     anchors,
-    suggested_anchor_ids: suggestAnchors(selectedAgentIds, anchors),
+    suggested_anchor_ids: suggestAnchors(events, anchors),
     resolved_at: now.toISOString(),
     evidence_state: scenarioEvidenceState(events),
   })

--- a/lib/terminal/script.ts
+++ b/lib/terminal/script.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { contentHash, stableId } from '@/lib/data/hash'
 import {
+  GAME_AGENT_IDS,
   GameScriptSchema,
   TERMINAL_CONTRACT_VERSION,
   type GameAgentId,
@@ -15,7 +16,7 @@ export const ScriptDraftSchema = z.object({
   causal_chain: z.array(z.object({
     agent_id: z.string().optional(),
     statement: z.string().min(1),
-  })).min(2).max(8),
+  })).min(2).max(GAME_AGENT_IDS.length + 1),
   key_conditions: z.array(z.string().min(1)).min(1).max(6),
   failure_conditions: z.array(z.string().min(1)).min(1).max(6),
 })


### PR DESCRIPTION
## Summary

- expand Swantail with football-native causal agent specifications and data-backed findings
- reduce the terminal to ten game-level agents with agent guidance controls
- derive Rest, Turnovers, Trenches, and Efficiency context from sourced observations
- establish a versioned Game Script v5 to Bet Station handoff while reserving player positions for the downstream product

## Validation

- `npm run test:run` (37 tests)
- `npm run type-check`
- `npm run build`
- local terminal renders exactly ten v5 agent controls